### PR TITLE
README.md - rev-parse command can be shorter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+sudo: false
 env:
   global:
   - secure: RrOxRkXn7IHW3kz1qg4X9XC99qB7Kt6tEFOlKSIpkZjFjst+TchaYzupt6ZplQ8Syj1tEhh6OibP3c0SIdtF4ztTViirgzRtbXXNbNICoYuDPxFFIWIN5eq6HgNnRf7aPy/oDi0sVtLmPaKG06MgviiSgEpnF6MhBgVKA6/CAfI=

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ deploygate {
     // this correspond to `debug` flavor and used for `uploadDeployGateDebug` task 
     debug {
       // ProTip: get git hash for current commit for easier troubleshooting
-      def hash = ["sh",  "-c",  "cd ${project.rootDir} ; git rev-parse --short HEAD"].execute().in.text.trim()
+      def hash = 'git rev-parse --short HEAD'.execute([], project.rootDir).in.text.trim()
       // set as build message
       message = "debug build ${hash}"
 


### PR DESCRIPTION
Thanks to [KeithYokoma's comment](http://qiita.com/chiastolite/items/4f36039fdd7ea1a5a86f#comment-aff31c3ace5acdbd9d40), it can be shorter using [`execute(String[], File)`](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/List.html#execute(java.lang.String[], java.io.File)) method.