### PR TITLE
Stricter check for headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the DeployGate plugin for the Gradle. You can build and deploy your apps
 1) Open your <code>build.gradle</code> on your project root and add a dependency.
 ```groovy
 dependency {
-  classpath 'com.deploygate:gradle:1.0.0'
+  classpath 'com.deploygate:gradle:1.0.1'
 }
 ```
 
@@ -51,7 +51,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.deploygate:gradle:1.0.0'   // add this line
+    classpath 'com.deploygate:gradle:1.0.1'   // add this line
   }
 }
 ```
@@ -92,7 +92,30 @@ deploygate {
 }
 ```
 
+### Environment Variables for CI
+
+If you are using Continuous Integration, you can set these environment variables 
+to provide default values for DeployGate Plugin instead of writing in `build.gradle`.
+
+ * `DEPLOYGATE_USER_NAME`
+ * `DEPLOYGATE_API_TOKEN`
+ * `DEPLOYGATE_MESSAGE`
+ * `DEPLOYGATE_DISTRIBUTION_KEY`
+ * `DEPLOYGATE_RELEASE_NOTE`
+ * `DEPLOYGATE_SOURCE_FILE`
+
+By using environment variables, you can avoid storing your credentials
+in your source code repository and compose deployment messages dynamically.
+
+Note that these values are used as default values so `build.gradle` may override them.
+
+
 # History
+
+## ver 1.0.1
+
+* Prevent invoking browser on headless environment
+* Allow passing values from environment variable
 
 ## ver 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ to provide default values for DeployGate Plugin instead of writing in `build.gra
 By using environment variables, you can avoid storing your credentials
 in your source code repository and compose deployment messages dynamically.
 
+For example, you can set application owner user to the organization you are belonging to
+by running task like:
+
+```
+DEPLOYGATE_USER_NAME=YourOrganizationName ./gradlew :app:uploadDeployGateDebug
+```
+
 Note that these values are used as default values so `build.gradle` may override them.
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 
 group = 'com.deploygate'
 archivesBaseName = 'gradle'
-version = '1.0.0'
+version = '1.0.1'
 
 repositories {
     mavenCentral()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,24 +2,39 @@ buildscript {
     repositories {
         jcenter()
     }
-
     dependencies {
-        classpath 'com.deploygate:gradle:0.6.2'
+        classpath 'com.deploygate:gradle:1.0.1'
     }
 }
-apply plugin: 'deploygate'
 
+apply plugin: 'deploygate'                    // add this *after* 'android' plugin
+
+// Optional configurations
 deploygate {
-    userName = ownerName
-    token = myToken
 
+    // If you are using automated build, you can specify your account credentials like this
+    userName = "[username of app owner]"
+    token = "[your API token]"
+
+    // You can also specify additional options for each flavor.
     apks {
-        example {
-            sourceFile = file("./DeployGateSample.apk")
 
-            //Below is optional
-            message = "example upload deploygate sample apk"
-            visibility = "public" // public or private
+        // this correspond to `debug` flavor and used for `uploadDeployGateDebug` task
+        debug {
+            // ProTip: get git hash for current commit for easier troubleshooting
+            def hash = 'git rev-parse --short HEAD'.execute([], project.rootDir).in.text.trim()
+            // set as build message
+            message = "debug build ${hash}"
+
+            // if you are using a distribution page, you can update it simultaneously
+            distributionKey = "1234567890abcdef1234567890abcdef"
+            releaseNote = "release note sample"
+        }
+
+        // this creates `uploadDeployGateCustom` task to upload arbitrary APK file
+        custom {
+            // set target file
+            sourceFile = "${project.rootDir}/app/build/some-custom-build.apk"
         }
     }
 }

--- a/example/gradle.properties.sample
+++ b/example/gradle.properties.sample
@@ -1,6 +1,3 @@
-ownerName=yourName
-myToken=yourToken
-
-// set proxy
+// You can configure HTTP Proxy setting via systemProp
 systemProp.https.proxyHost=proxyHost
 systemProp.https.proxyPort=proxyPort

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
@@ -32,5 +32,4 @@ class DeployTarget implements Named {
         }
         return params
     }
-
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.groovy
@@ -49,11 +49,19 @@ class LoginTask extends DefaultTask {
 
     def setupCredential() {
         saved = false
-        if (Desktop.isDesktopSupported()) {
+        if ( !isAwtHeadless() && !isCiEnvironment() && Desktop.isDesktopSupported() ) {
             setupBrowser()
         } else {
             setupTerminal()
         }
+    }
+
+    boolean isCiEnvironment() {
+        System.getenv('CI') || System.getenv('JENKINS_URL')
+    }
+
+    boolean isAwtHeadless() {
+        System.getProperty('java.awt.headless')
     }
 
     def setupTerminal() {

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
@@ -47,10 +47,10 @@ class UploadTask extends DefaultTask {
     private def fillFromEnv(DeployTarget target) {
         target.with {
             sourceFile = sourceFile ?: project.file(System.getenv('DEPLOYGATE_SOURCE_FILE'))
-            message = message ?: project.file(System.getenv('DEPLOYGATE_MESSAGE'))
-            distributionKey = distributionKey ?: project.file(System.getenv('DEPLOYGATE_DISTRIBUTION_KEY'))
-            releaseNote = releaseNote ?: project.file(System.getenv('DEPLOYGATE_RELEASE_NOTE'))
-            visibility = visibility ?: project.file(System.getenv('DEPLOYGATE_VISIBILITY'))
+            message = message ?: System.getenv('DEPLOYGATE_MESSAGE')
+            distributionKey = distributionKey ?: System.getenv('DEPLOYGATE_DISTRIBUTION_KEY')
+            releaseNote = releaseNote ?: System.getenv('DEPLOYGATE_RELEASE_NOTE')
+            visibility = visibility ?: System.getenv('DEPLOYGATE_VISIBILITY')
         }
     }
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
@@ -30,6 +30,7 @@ class UploadTask extends DefaultTask {
             target = new DeployTarget(outputName)
         if (!target.sourceFile)
             target.sourceFile = defaultSourceFile
+        fillFromEnv(target)
 
         if (!target.sourceFile?.exists())
             throw new GradleException("APK file not found")
@@ -37,11 +38,20 @@ class UploadTask extends DefaultTask {
         project.deploygate.notifyServer 'start_upload', [ 'length': Long.toString(target.sourceFile.length()) ]
 
         def res = uploadProject(project, target)
-
         if (res.error)
             project.deploygate.notifyServer 'upload_finished', [ 'error': true, message: res.message ]
         else
             project.deploygate.notifyServer 'upload_finished', [ 'path': res.results.path ]
+    }
+
+    private def fillFromEnv(DeployTarget target) {
+        target.with {
+            sourceFile = sourceFile ?: project.file(System.getenv('DEPLOYGATE_SOURCE_FILE'))
+            message = message ?: project.file(System.getenv('DEPLOYGATE_MESSAGE'))
+            distributionKey = distributionKey ?: project.file(System.getenv('DEPLOYGATE_DISTRIBUTION_KEY'))
+            releaseNote = releaseNote ?: project.file(System.getenv('DEPLOYGATE_RELEASE_NOTE'))
+            visibility = visibility ?: project.file(System.getenv('DEPLOYGATE_VISIBILITY'))
+        }
     }
 
     def uploadProject(Project project, DeployTarget apk) {


### PR DESCRIPTION
It turns out `Desktop.isDesktopSupported()` returns true on Circle CI and it tries to start a browser.

To prevent this behaviour, we should check environment variables in addition to the function currently used.