### PR TITLE
Fix Readme and build.gradle file of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ deploygate {
     // this creates `uploadDeployGateCustom` task to upload arbitrary APK file 
     custom {
       // set target file
-      sourceFile = "${project.rootDir}/app/build/some-custom-build.apk"
+      sourceFile = file("${project.rootDir}/app/build/some-custom-build.apk")
     }
   }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -34,7 +34,7 @@ deploygate {
         // this creates `uploadDeployGateCustom` task to upload arbitrary APK file
         custom {
             // set target file
-            sourceFile = "${project.rootDir}/app/build/some-custom-build.apk"
+            sourceFile = file("${project.rootDir}/app/build/some-custom-build.apk")
         }
     }
 }


### PR DESCRIPTION
"Cannot cast" error message appears when I compiled [this project's example](https://github.com/DeployGate/gradle-deploygate-plugin/tree/master/example). 
I think it's because `sourceFile` is defined as `File`, but it is used as a `String`.
https://github.com/DeployGate/gradle-deploygate-plugin/blob/master/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy#L8