### PR TITLE
Supported noAssemble option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ deploygate {
       // set as build message
       message = "debug build ${hash}"
 
+      // If this property is `true` , Skip dependency of `assemble` task from `uploadDeployGate` task
+      // The default value is `false`
+      noAssemble = true
+
       // if you are using a distribution page, you can update it simultaneously
       distributionKey = "1234567890abcdef1234567890abcdef"
       releaseNote = "release note sample"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -26,6 +26,10 @@ deploygate {
             // set as build message
             message = "debug build ${hash}"
 
+            // If this property is `true` , Skip dependency of `assemble` task from `uploadDeployGate` task
+            // The default value is `false`
+            noAssemble = true
+
             // if you are using a distribution page, you can update it simultaneously
             distributionKey = "1234567890abcdef1234567890abcdef"
             releaseNote = "release note sample"

--- a/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
@@ -71,10 +71,17 @@ class DeployGate implements Plugin<Project> {
         }
 
         def capitalized = name.capitalize()
+        def dependsOn = []
+        DeployTarget target = project.deploygate.apks.findByName(name)
+        if (!target || !target.noAssemble) {
+            dependsOn.add(assemble)
+        }
+        dependsOn.add(loginTask)
+
         def taskName = "uploadDeployGate${capitalized}"
         project.task(taskName,
                 type: UploadTask,
-                dependsOn: ([assemble, loginTask] - null),
+                dependsOn: (dependsOn - null),
                 overwrite: true) {
 
             def desc = "Deploy assembled ${capitalized} to DeployGate"

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
@@ -10,6 +10,7 @@ class DeployTarget implements Named {
     String distributionKey
     String releaseNote
     String visibility = "private"
+    boolean noAssemble
 
     DeployTarget() {}
 
@@ -31,6 +32,7 @@ class DeployTarget implements Named {
         if (visibility != null) {
             params.put("visibility", visibility)
         }
+        params.put("no_asssemble", noAssemble)
         return params
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
@@ -32,7 +32,6 @@ class DeployTarget implements Named {
         if (visibility != null) {
             params.put("visibility", visibility)
         }
-        params.put("no_asssemble", noAssemble)
         return params
     }
 }

--- a/src/test/groovy/com/deploygate/gradle/plugins/DeployTargetTest.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/DeployTargetTest.groovy
@@ -16,7 +16,7 @@ class DeployTargetTest {
 
         DeployTarget apk = new DeployTarget(name: name, sourceFile: file, message: message, distributionKey: distributionKey, releaseNote: releaseNote, visibility: visibility, noAssemble: noAssemble)
         checkDeployTarget(apk, name, file, message, distributionKey, releaseNote, visibility, noAssemble)
-        checkParams(apk, message, distributionKey, releaseNote, visibility, noAssemble)
+        checkParams(apk, message, distributionKey, releaseNote, visibility)
     }
 
     @Test
@@ -32,7 +32,7 @@ class DeployTargetTest {
         DeployTarget apk = new DeployTarget(name)
         apk.sourceFile = file
         checkDeployTarget(apk, name, file, message, distributionKey, releaseNote, visibility, noAssemble)
-        checkParams(apk, message, distributionKey, releaseNote, visibility, noAssemble)
+        checkParams(apk, message, distributionKey, releaseNote, visibility)
     }
 
     public void checkDeployTarget(DeployTarget apk, String name, File file, String message, String distributionKey, String releaseNote, String visibility, boolean noAssemble) {
@@ -46,12 +46,11 @@ class DeployTargetTest {
         assert apk.noAssemble == noAssemble
     }
 
-    public void checkParams(DeployTarget apk, String message, String distributionKey, String releaseNote, String visibility, boolean noAssemble) {
+    public void checkParams(DeployTarget apk, String message, String distributionKey, String releaseNote, String visibility) {
         HashMap<String, String> params = apk.toParams()
         assert params["message"] == message
         assert params["distribution_key"] == distributionKey
         assert params["release_note"] == releaseNote
         assert params["visibility"] == visibility
-        assert params["no_asssemble"] == noAssemble
     }
 }

--- a/src/test/groovy/com/deploygate/gradle/plugins/DeployTargetTest.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/DeployTargetTest.groovy
@@ -12,10 +12,11 @@ class DeployTargetTest {
         String distributionKey = "test distribution key"
         String releaseNote     = "test release note"
         String visibility      = "public"
+        boolean noAssemble     = true
 
-        DeployTarget apk = new DeployTarget(name: name, sourceFile: file, message: message, distributionKey: distributionKey, releaseNote: releaseNote, visibility: visibility)
-        checkDeployTarget(apk, name, file, message, distributionKey, releaseNote, visibility)
-        checkParams(apk, message, distributionKey, releaseNote, visibility)
+        DeployTarget apk = new DeployTarget(name: name, sourceFile: file, message: message, distributionKey: distributionKey, releaseNote: releaseNote, visibility: visibility, noAssemble: noAssemble)
+        checkDeployTarget(apk, name, file, message, distributionKey, releaseNote, visibility, noAssemble)
+        checkParams(apk, message, distributionKey, releaseNote, visibility, noAssemble)
     }
 
     @Test
@@ -26,14 +27,15 @@ class DeployTargetTest {
         String distributionKey = null
         String releaseNote     = null
         String visibility      = "private"
+        boolean noAssemble     = false
 
         DeployTarget apk = new DeployTarget(name)
         apk.sourceFile = file
-        checkDeployTarget(apk, name, file, message, distributionKey, releaseNote, visibility)
-        checkParams(apk, message, distributionKey, releaseNote, visibility)
+        checkDeployTarget(apk, name, file, message, distributionKey, releaseNote, visibility, noAssemble)
+        checkParams(apk, message, distributionKey, releaseNote, visibility, noAssemble)
     }
 
-    public void checkDeployTarget(DeployTarget apk, String name, File file, String message, String distributionKey, String releaseNote, String visibility) {
+    public void checkDeployTarget(DeployTarget apk, String name, File file, String message, String distributionKey, String releaseNote, String visibility, boolean noAssemble) {
         assert apk instanceof DeployTarget
         assert apk.name == name
         assert apk.sourceFile == file
@@ -41,13 +43,15 @@ class DeployTargetTest {
         assert apk.distributionKey == distributionKey
         assert apk.releaseNote == releaseNote
         assert apk.visibility == visibility
+        assert apk.noAssemble == noAssemble
     }
 
-    public void checkParams(DeployTarget apk, String message, String distributionKey, String releaseNote, String visibility) {
+    public void checkParams(DeployTarget apk, String message, String distributionKey, String releaseNote, String visibility, boolean noAssemble) {
         HashMap<String, String> params = apk.toParams()
         assert params["message"] == message
         assert params["distribution_key"] == distributionKey
         assert params["release_note"] == releaseNote
         assert params["visibility"] == visibility
+        assert params["no_asssemble"] == noAssemble
     }
 }


### PR DESCRIPTION
Property `noAssemble` is true, Remove dependency of assemble task from uploadDeployGate task.