### PR TITLE
Don't specify default visibility to upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.jfrog.bintray'
 
 group = 'com.deploygate'
 archivesBaseName = 'gradle'
-version = '1.1.1'
+version = '1.1.2'
 
 repositories {
     mavenCentral()
@@ -51,7 +51,7 @@ bintray {
         vcsUrl = 'https://github.com/DeployGate/gradle-deploygate-plugin.git'
         githubRepo = 'DeployGate/gradle-deploygate-plugin'
         version {
-            name = '1.1.1'
+            name = '1.1.2'
             released = new Date()
         }
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
@@ -42,7 +42,7 @@ class DeployGate implements Plugin<Project> {
         // variant is for applicationFlavors
         project.android.applicationVariants.all { variant ->
             // variant is for splits
-            variant.outputs.eachWithIndex { output, idx ->
+            variant.outputs.each { output ->
                 createTask(project, output, loginTask)
                 tasksToCreate.remove output.name
             }

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
@@ -6,10 +6,10 @@ class DeployTarget implements Named {
     String name
 
     File sourceFile
-    String message = ""
+    String message
     String distributionKey
     String releaseNote
-    String visibility = "private"
+    String visibility
     boolean noAssemble
 
     DeployTarget() {}

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
@@ -29,7 +29,7 @@ class UploadTask extends DefaultTask {
 
         DeployTarget target = findTarget()
         if (!target.sourceFile?.exists())
-            throw new GradleException("APK file was not found. If you are using Android O Developer Preview, you need to set `sourceFile` in your build.gradle. See https://docs.deploygate.com/docs/gradle-plugin")
+            throw new GradleException("APK file was not found. If you are using Android Build Tools >= 3.0.0, you need to set `sourceFile` in your build.gradle. See https://docs.deploygate.com/docs/gradle-plugin")
 
         onBeforeUpload(target)
         def res = uploadProject(project, target)

--- a/src/test/groovy/com/deploygate/gradle/plugins/DeployTargetTest.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/DeployTargetTest.groovy
@@ -23,10 +23,10 @@ class DeployTargetTest {
     public void argsNullTest() {
         String name            = "name"
         File file              = null
-        String message         = ""
+        String message         = null
         String distributionKey = null
         String releaseNote     = null
-        String visibility      = "private"
+        String visibility      = null
         boolean noAssemble     = false
 
         DeployTarget apk = new DeployTarget(name)


### PR DESCRIPTION
This changeset fixes the problem that first app upload is *always* failing with Personal Free plan, which is default plan for new users.