### PR TITLE
Retrieve APK file location from variant scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Note that these values are used as default values so `build.gradle` may override
 
 # Changes
 
+## ver 1.1.3
+
+ * Restore auto configuring APK file path functionality (supports Android Gradle Plugin 3.0.0-alpha4) 
+
 ## ver 1.1.1
 
  * Workaround for the issue on Android Gradle Plugin 3.0 Preview

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.jfrog.bintray'
 
 group = 'com.deploygate'
 archivesBaseName = 'gradle'
-version = '1.1.2'
+version = '1.1.3'
 
 repositories {
     mavenCentral()
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
+
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     compile 'org.apache.httpcomponents:httpmime:4.2.5'
     runtime 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
@@ -51,7 +52,7 @@ bintray {
         vcsUrl = 'https://github.com/DeployGate/gradle-deploygate-plugin.git'
         githubRepo = 'DeployGate/gradle-deploygate-plugin'
         version {
-            name = '1.1.2'
+            name = '1.1.3'
             released = new Date()
         }
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/Config.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/Config.groovy
@@ -1,7 +1,7 @@
 package com.deploygate.gradle.plugins
 
 class Config {
-    static final def VERSION = '1.0.4'
+    static final def VERSION = '1.1.3'
     static final def USER_AGENT = "gradle-deploygate-plugin/${VERSION}"
     static final def DEPLOYGATE_ROOT = 'https://deploygate.com'
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
@@ -114,7 +114,7 @@ class DeployGate implements Plugin<Project> {
 
         if (variant) try {
             // Android plugin 3.0.0-alpha way
-            return variant.variantData.scope.apkLocation()
+            return variant.variantData.scope.apkLocation
         } catch (Exception ignored) {}
     }
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadTask.groovy
@@ -29,7 +29,7 @@ class UploadTask extends DefaultTask {
 
         DeployTarget target = findTarget()
         if (!target.sourceFile?.exists())
-            throw new GradleException("APK file was not found. If you are using Android Build Tools >= 3.0.0, you need to set `sourceFile` in your build.gradle. See https://docs.deploygate.com/docs/gradle-plugin")
+            throw new GradleException("APK file ${target.sourceFile} was not found. If you are using Android Build Tools >= 3.0.0, you need to set `sourceFile` in your build.gradle. See https://docs.deploygate.com/docs/gradle-plugin")
 
         onBeforeUpload(target)
         def res = uploadProject(project, target)


### PR DESCRIPTION
Trial implementation of retrieving APK file location from VariantScope, which is internal API of Gradle Android Plugin.

The behavior might be changed in future release of the plugin so it is encapsulated within a try-catch.