### PR TITLE
Fix producing corrupted task names for flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Note that these values are used as default values so `build.gradle` may override
 
 # Changes
 
+## ver 1.1.4
+
+ * Fix producing corrupted task names for flavors on Android Plugin for Gradle 3.0.0 (like uploadDeployGateDev-debug for uploadDeployGateDevDebug)
+
 ## ver 1.1.3
 
  * Restore auto configuring APK file path functionality (supports Android Gradle Plugin 3.0.0-alpha4) 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.jfrog.bintray'
 
 group = 'com.deploygate'
 archivesBaseName = 'gradle'
-version = '1.1.3'
+version = '1.1.4'
 
 repositories {
     mavenCentral()
@@ -52,7 +52,7 @@ bintray {
         vcsUrl = 'https://github.com/DeployGate/gradle-deploygate-plugin.git'
         githubRepo = 'DeployGate/gradle-deploygate-plugin'
         version {
-            name = '1.1.3'
+            name = '1.1.4'
             released = new Date()
         }
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/Config.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/Config.groovy
@@ -1,7 +1,7 @@
 package com.deploygate.gradle.plugins
 
 class Config {
-    static final def VERSION = '1.1.3'
+    static final def VERSION = '1.1.4'
     static final def USER_AGENT = "gradle-deploygate-plugin/${VERSION}"
     static final def DEPLOYGATE_ROOT = 'https://deploygate.com'
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/DeployGate.groovy
@@ -63,7 +63,7 @@ class DeployGate implements Plugin<Project> {
         if (output instanceof String) {
             name = output
         } else {
-            name = output.name
+            name = variant?.name ?: output.name
             isUniversal = output.outputs.get(0).filters.size() == 0
             assemble = output.assemble
 


### PR DESCRIPTION
Retrieve task name from `variant`, instead of `output`.