### PR TITLE
Support uploading a universal apk from Android App Bundle (depends on #52)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.deploygate'
@@ -10,13 +11,15 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 repositories {
-    mavenCentral()
+    google()
+    jcenter()
 }
 
 dependencies {
     compile gradleApi()
     compile localGroovy()
 
+    compile 'com.android.tools.build:bundletool:0.5.0'
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     compile 'org.apache.httpcomponents:httpmime:4.2.5'
     runtime 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
@@ -47,7 +50,7 @@ bintray {
     key = System.getenv('BINTRAY_KEY')
     pkg {
         repo = 'maven'
-        name = 'gradle'
+        name = project.archivesBaseName
         userOrg = 'deploygate'
         licenses = ['Apache-2.0']
         websiteUrl = 'https://github.com/DeployGate/gradle-deploygate-plugin'
@@ -55,12 +58,24 @@ bintray {
         vcsUrl = 'https://github.com/DeployGate/gradle-deploygate-plugin.git'
         githubRepo = 'DeployGate/gradle-deploygate-plugin'
         version {
-            name = '1.1.5'
+            name = project.version
             released = new Date()
         }
     }
 
     configurations = ['archives']
+}
+
+// For publishToMavenLocal
+publishing {
+    publications {
+        pluginPublication(MavenPublication) {
+            from components.java
+            groupId project.group
+            artifactId project.archivesBaseName
+            version project.version
+        }
+    }
 }
 
 buildscript {

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/ApkInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/ApkInfo.groovy
@@ -8,4 +8,6 @@ interface ApkInfo {
     boolean isSigningReady()
 
     boolean isUniversalApk()
+
+    SigningConfig getSigningConfig()
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/AppBundleInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/AppBundleInfo.groovy
@@ -1,0 +1,37 @@
+package com.deploygate.gradle.plugins.artifacts
+
+import com.deploygate.gradle.plugins.entities.DeployTarget
+import org.gradle.api.Project
+
+class AppBundleInfo {
+    private final ApkInfo apkInfo
+
+    private File apksFile
+    private File bundleFile
+
+    AppBundleInfo(ApkInfo apkInfo) {
+        this.apkInfo = apkInfo
+    }
+
+    File getApksFile() {
+        if (apksFile) {
+            return apksFile
+        }
+
+        return apksFile = new File(apkInfo.apkFile.parentFile, apkInfo.apkFile.name.replace(".apk", ".apks"))
+    }
+
+    File getBundleFile(Project project) {
+        if (bundleFile) {
+            return bundleFile
+        }
+
+        def deployTarget = project.deploygate.apks.findByName(apkInfo.variantName) as DeployTarget
+
+        return bundleFile = project.file(deployTarget?.bundle?.source ?: "build/outputs/bundle/${apkInfo.variantName}/${project.name}.aab")
+    }
+
+    SigningConfig getSigningConfig() {
+        return apkInfo.signingConfig
+    }
+}

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/SigningConfig.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/SigningConfig.groovy
@@ -1,0 +1,27 @@
+package com.deploygate.gradle.plugins.artifacts
+
+import com.android.tools.build.bundletool.model.SigningConfiguration
+import com.android.tools.build.bundletool.utils.flags.Flag
+
+class SigningConfig {
+    private final File storeFile
+    private final String keyPassword
+    private final String keyAlias
+    private final String storePassword
+
+    SigningConfig(File storeFile, String keyPassword, String keyAlias, String storePassword) {
+        this.storeFile = storeFile
+        this.keyPassword = keyPassword
+        this.keyAlias = keyAlias
+        this.storePassword = storePassword
+    }
+
+    SigningConfiguration toSigningConfiguration() {
+        SigningConfiguration.extractFromKeystore(
+                storeFile.toPath(),
+                keyAlias,
+                Optional.ofNullable(Flag.Password.createFromFlagValue("pass:${storePassword}")),
+                Optional.ofNullable(Flag.Password.createFromFlagValue("pass:${keyPassword}"))
+        )
+    }
+}

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/AppBundleTarget.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/AppBundleTarget.groovy
@@ -1,0 +1,9 @@
+package com.deploygate.gradle.plugins.entities
+
+import org.gradle.util.Configurable
+
+interface AppBundleTarget extends Configurable<AppBundleTarget> {
+    void setSource(String path)
+
+    void setSkipBundle(boolean skipBundle)
+}

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployGateExtension.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployGateExtension.groovy
@@ -13,6 +13,8 @@ class DeployGateExtension {
     NamedDomainObjectContainer<DeployTarget> apks
     String notifyKey = null
 
+    String aapt2Path
+
     DeployGateExtension(NamedDomainObjectContainer<DeployTarget> apkTargets) {
         this.apks = apkTargets
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/entities/DeployTarget.groovy
@@ -12,10 +12,16 @@ class DeployTarget implements Named {
     String visibility
     boolean noAssemble
 
+    AppBundleTarget bundle
+
     DeployTarget() {}
 
     DeployTarget(String name) {
         this.name = name
+    }
+
+    def bundle(Closure closure) {
+        bundle.configure(closure)
     }
 
     HashMap<String, String> toParams() {

--- a/src/main/groovy/com/deploygate/gradle/plugins/utils/AndroidPlatformUtils.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/utils/AndroidPlatformUtils.groovy
@@ -1,0 +1,106 @@
+package com.deploygate.gradle.plugins.utils
+
+import org.gradle.api.Project
+
+class AndroidPlatformUtils {
+    private static AGPVersion AGP_VERSION
+
+    static String getAapt2Location(Project project) {
+        return project.deploygate.aapt2Path ?: System.getenv('DEPLOYGATE_APPT2_PATH') ?: "${getSdkHome(project)}/build-tools/${getBuildToolsVersion(project)}/aapt2"
+    }
+
+    static AGPVersion getAGPVersion() {
+        if (!AGP_VERSION) {
+            AGP_VERSION = AndroidPlatformUtils.AGPVersion.parse(getVersionString())
+        }
+
+        return AGP_VERSION
+    }
+
+    static boolean isAppBundleSupported() {
+        return getAGPVersion().major >= 3 && getAGPVersion().minor >= 2
+    }
+
+    private static String getVersionString() {
+        try {
+            return Class.forName("com.android.builder.model.Version").getField("ANDROID_GRADLE_PLUGIN_VERSION").get(null)
+        } catch (Throwable ignored) {
+        }
+
+        // before 3.1
+        try {
+            return Class.forName("com.android.builder.Version").getField("ANDROID_GRADLE_PLUGIN_VERSION").get(null)
+        } catch (Throwable ignored) {
+        }
+
+        return Integer.MAX_VALUE + ".0.0"
+    }
+
+    private static String getBuildToolsVersion(Project project) {
+        try {
+            def buildToolRevision = Class.forName('com.android.repository.Revision').getMethod('safeParseRevision', String.class).invoke(null, project.android.buildToolsVersion)
+
+            def klass = Class.forName('com.android.builder.core.AndroidBuilder')
+
+            if (buildToolRevision < klass.getField('MIN_BUILD_TOOLS_REV').get(null)) {
+                buildToolRevision = klass.getField('DEFAULT_BUILD_TOOLS_REVISION').get(null)
+            }
+
+            return buildToolRevision
+        } catch (Throwable ignored) {
+            // print error
+            return null
+        }
+    }
+
+    private static String getSdkHome(Project project) {
+        return project.rootProject.file('local.properties').with {
+            String temp = null
+
+            if (exists()) {
+                def m = text =~ /sdk\.dir=(.*)/
+
+                temp = m.find() ? m.group(1) : null
+            }
+
+            temp ?: System.getenv('ANDROID_HOME')
+        }
+    }
+
+    private static class AGPVersion {
+        final String fullVersion
+        final int major
+        final int minor
+        final int patch
+        final String identifier
+
+        AGPVersion(String fullVersion, int major, int minor, int patch, String identifier) {
+            this.fullVersion = fullVersion
+            this.major = major
+            this.minor = minor
+            this.patch = patch
+            this.identifier = identifier
+        }
+
+        def static parse(String fullVersion) {
+            def t = fullVersion.split("-", 1)
+
+            def versions = t[0].split("\\.")
+            def identifier = t.size() > 1 ? t[1] : null
+
+            def major = Integer.parseInt(versions[0])
+            def minor = Integer.parseInt(versions[1])
+            def patch = versions.length > 3 ? Integer.parseInt(versions[2]) : 0
+
+            return new AGPVersion(fullVersion, major, minor, patch, identifier)
+        }
+
+        boolean isBefore300Preview() {
+            return major < 3
+        }
+
+        boolean is300Preview() {
+            return fullVersion.startsWith("3.0.0-")
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This change doesn't aim to upload apks/aab directly.
Instead of that, this will add tasks to upload a universal apk which is built from Android App Bundle file.
*This is still experimental implementation.*

# Background

The ideal goal of supporting aab is to allow users to upload aab or apks files directly and distribute them.
However, we haven't supported the big feature yet.

It would be developers' help to automate the flow which builds a universal apk from aab and uploads it
