### PR TITLE
Evaluate a package application provider immediately if skipAssemble is true

### DIFF
--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/factory/AGPBasedUploadApkTaskFactory.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/factory/AGPBasedUploadApkTaskFactory.groovy
@@ -39,6 +39,12 @@ class AGPBasedUploadApkTaskFactory extends DeployGateTaskFactory implements Uplo
             dgTask.configuration = configuration
             dgTask.applyTaskProfile()
         }
+
+        if (deployment?.skipAssemble) {
+            // a package application provider may not be evaluated in some cases.
+            // ref: https://github.com/DeployGate/gradle-deploygate-plugin/issues/86
+            applicationVariant.lazyPackageApplication().get()
+        }
     }
 
     @Override

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -14,7 +14,8 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
     AGPEnv[] getTestTargetAGPEnvs() {
         return [
                 new AGPEnv("3.3.2", "4.10.1"),
-                new AGPEnv("3.4.0-beta05", "5.1.1"),
+                new AGPEnv("3.4.0", "5.1.1"),
+                new AGPEnv("3.5.0", "5.4.1"),
         ]
     }
 

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
@@ -14,7 +14,8 @@ class AcceptanceTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.1.0", "4.4"),
                 new AGPEnv("3.2.0", "4.6"),
                 new AGPEnv("3.3.2", "4.10.1"),
-                new AGPEnv("3.4.0-beta05", "5.1.1"),
+                new AGPEnv("3.4.1", "5.1.1"),
+                new AGPEnv("3.5.0", "5.4.1"),
         ]
     }
 }

--- a/src/test/acceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
@@ -63,6 +63,7 @@ class AndroidGradlePluginAcceptanceSpec extends Specification {
         "3.1.0"          | "4.4"
         "3.2.0"          | "4.6"
         "3.3.2"          | "4.10.1"
-        "3.4.0-beta05"   | "5.1.1"
+        "3.4.1"          | "5.1.1"
+        "3.5.0"          | "5.4.1"
     }
 }

--- a/src/test/acceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
@@ -52,7 +52,8 @@ class GradleCompatAcceptanceSpec extends Specification {
                 "4.8",
                 "4.9",
                 "4.10.1",
-                "5.1.1"
+                "5.1.1",
+                "5.4.1"
         ]
     }
 }


### PR DESCRIPTION
Fixed #86 

Android Gradle Plugin 3.5 (and later probably) won't configure unused package applications. If skipAssemble is true, DeployGate plugin cannot receive a configuration event from the provider so this issue has happened. Otherwise, assemble tasks will do it surely.