### PR TITLE
[Will be never merged] Applied a patch to work with AndroidStudio 3.6.0-beta01

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 ext {
     agpVersion = '3.3.2'
+    unstableAgpVersion = '3.6.0-beta01'
 }
 
 sourceSets {

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
@@ -10,11 +10,11 @@ class PackageAppTaskCompat {
     }
 
     @Nonnull
-    static ApkInfo getApkInfo(@Nonnull /* PackageApplication */ packageAppTask) {
+    static ApkInfo getApkInfo(@Nonnull /* com.android.build.gradle.tasks.PackageApplication */ packageAppTask) {
         String variantName = packageAppTask.name
         // outputScope is retrieved by the reflection
         Collection<String> apkNames = packageAppTask.outputScope.apkDatas*.outputFileName
-        File outputDir = packageAppTask.outputDirectory
+        File outputDir = getOutputDirectory(packageAppTask)
         boolean isUniversal = apkNames.size() == 1
         boolean isSigningReady = hasSigningConfig(packageAppTask)
 
@@ -30,8 +30,18 @@ class PackageAppTaskCompat {
     static boolean hasSigningConfig(packageAppTask) {
         if (!AndroidGradlePlugin.isSigningConfigCollectionSupported()) {
             return packageAppTask.signingConfig != null
-        } else {
+        } else if (!AndroidGradlePlugin.isSigningConfigProviderSupported()) {
             return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.isEmpty()
+        } else {
+            return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.signingConfigFileCollection // no need to check `empty` for now
+        }
+    }
+
+    static File getOutputDirectory(packageAppTask) {
+        if (!AndroidGradlePlugin.isOutputDirectoryProviderSupported()) {
+            return packageAppTask.outputDirectory
+        } else {
+            return packageAppTask.outputDirectory.getAsFile().get()
         }
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
@@ -45,15 +45,23 @@ class AndroidGradlePlugin {
     }
 
     static boolean isAppBundleSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor > 1
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 2
     }
 
     static boolean isSigningConfigCollectionSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor > 2
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
     }
 
     static boolean isTaskProviderBased() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor > 2
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
+    }
+
+    static boolean isSigningConfigProviderSupported() {
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
+    }
+
+    static boolean isOutputDirectoryProviderSupported() {
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
     }
 
     @Nonnull

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -15,7 +15,8 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
         return [
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.0", "5.1.1"),
-                new AGPEnv("3.5.0", "5.4.1"),
+                new AGPEnv("3.5.1", "5.4.1"),
+                new AGPEnv("3.6.0-beta01", "5.6.1"),
         ]
     }
 

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -15,8 +15,8 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
         return [
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.0", "5.1.1"),
-                new AGPEnv("3.5.1", "5.4.1"),
-                new AGPEnv("3.6.0-beta01", "5.6.1"),
+                new AGPEnv("3.5.2", "5.4.1"),
+                new AGPEnv("3.6.0-beta03", "5.6.1"),
         ]
     }
 

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -16,7 +16,7 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.0", "5.1.1"),
                 new AGPEnv("3.5.2", "5.4.1"),
-                new AGPEnv("3.6.0-beta03", "5.6.1"),
+                new AGPEnv("3.6.0-beta02", "5.6.1"),
         ]
     }
 

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
@@ -16,7 +16,7 @@ class AcceptanceTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.1", "5.1.1"),
                 new AGPEnv("3.5.2", "5.4.1"),
-                new AGPEnv("3.6.0-beta03", "5.6.1"),
+                new AGPEnv("3.6.0-beta02", "5.6.1"),
         ]
     }
 }

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
@@ -15,8 +15,8 @@ class AcceptanceTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.2.0", "4.6"),
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.1", "5.1.1"),
-                new AGPEnv("3.5.1", "5.4.1"),
-                new AGPEnv("3.6.0-beta01", "5.6.1"),
+                new AGPEnv("3.5.2", "5.4.1"),
+                new AGPEnv("3.6.0-beta03", "5.6.1"),
         ]
     }
 }

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
@@ -15,7 +15,8 @@ class AcceptanceTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.2.0", "4.6"),
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.1", "5.1.1"),
-                new AGPEnv("3.5.0", "5.4.1"),
+                new AGPEnv("3.5.1", "5.4.1"),
+                new AGPEnv("3.6.0-beta01", "5.6.1"),
         ]
     }
 }


### PR DESCRIPTION
Fixed #90 

AndroidStudio 3.6.0-alphaXX has worked fine on the current master though, the signature of PackageApplication class has been changed since 3.6.0-beta01.
This branch should distribute the fixed version as a snapshot until the stable version will be released.

Checked the behavior on the following environments.

- [x] beta01
- [x] beta02
- [x] beta03
- [x] beta04
- [x] beta05