### PR TITLE
Support AndroidStudio rc01

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 ext {
     agpVersion = '3.3.2'
+    unstableAgpVersion = '3.6.0-beta01'
 }
 
 sourceSets {

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
@@ -15,7 +15,7 @@ class PackageAppTaskCompat {
     static ApkInfo getApkInfo(@Nonnull /* PackageApplication */ packageAppTask, @Nonnull String variantName) {
         // outputScope is retrieved by the reflection
         Collection<String> apkNames = packageAppTask.outputScope.apkDatas*.outputFileName
-        File outputDir = packageAppTask.outputDirectory
+        File outputDir = getOutputDirectory(packageAppTask)
         boolean isUniversal = apkNames.size() == 1
         boolean isSigningReady = hasSigningConfig(packageAppTask)
 
@@ -51,8 +51,18 @@ class PackageAppTaskCompat {
     static boolean hasSigningConfig(packageAppTask) {
         if (!AndroidGradlePlugin.isSigningConfigCollectionSupported()) {
             return packageAppTask.signingConfig != null
-        } else {
+        } else if (!AndroidGradlePlugin.isSigningConfigProviderSupported()) {
             return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.isEmpty()
+        } else {
+            return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.signingConfigFileCollection // no need to check `empty` for now
+        }
+    }
+
+    static File getOutputDirectory(packageAppTask) {
+        if (!AndroidGradlePlugin.isOutputDirectoryProviderSupported()) {
+            return packageAppTask.outputDirectory
+        } else {
+            return packageAppTask.outputDirectory.getAsFile().get()
         }
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
@@ -46,15 +46,23 @@ class AndroidGradlePlugin {
     }
 
     static boolean isAppBundleSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor > 1
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 2
     }
 
     static boolean isSigningConfigCollectionSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor > 2
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
     }
 
     static boolean isTaskProviderBased() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor > 2
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
+    }
+
+    static boolean isSigningConfigProviderSupported() {
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
+    }
+
+    static boolean isOutputDirectoryProviderSupported() {
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
     }
 
     static boolean isAppBundleArchiveNameChanged() {

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
@@ -57,16 +57,16 @@ class AndroidGradlePlugin {
         return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
     }
 
+    static boolean isAppBundleArchiveNameChanged() {
+        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 5
+    }
+
     static boolean isSigningConfigProviderSupported() {
         return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
     }
 
     static boolean isOutputDirectoryProviderSupported() {
         return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
-    }
-
-    static boolean isAppBundleArchiveNameChanged() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 5
     }
 
     @Nonnull

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -15,7 +15,8 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
         return [
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.0", "5.1.1"),
-                new AGPEnv("3.5.0", "5.4.1"),
+                new AGPEnv("3.5.1", "5.4.1"),
+                new AGPEnv("3.6.0-beta01", "5.6.1"),
         ]
     }
 

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -16,7 +16,7 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.0", "5.1.1"),
                 new AGPEnv("3.5.1", "5.4.1"),
-                new AGPEnv("3.6.0-beta01", "5.6.1"),
+                new AGPEnv("3.6.0-rc01", "5.6.4"),
         ]
     }
 

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
@@ -16,7 +16,7 @@ class AcceptanceTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.1", "5.1.1"),
                 new AGPEnv("3.5.1", "5.4.1"),
-                new AGPEnv("3.6.0-beta01", "5.6.1"),
+                new AGPEnv("3.6.0-rc01", "5.6.4"),
         ]
     }
 }

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestSpec.groovy
@@ -15,7 +15,8 @@ class AcceptanceTestSpec extends AcceptanceTestBaseSpec {
                 new AGPEnv("3.2.0", "4.6"),
                 new AGPEnv("3.3.2", "4.10.1"),
                 new AGPEnv("3.4.1", "5.1.1"),
-                new AGPEnv("3.5.0", "5.4.1"),
+                new AGPEnv("3.5.1", "5.4.1"),
+                new AGPEnv("3.6.0-beta01", "5.6.1"),
         ]
     }
 }


### PR DESCRIPTION
AndroidStudio 3.6.0's breaking changes

- PackageApplication#outputDirectory has become Provider-based API
- PackageApplicaiton#signingConfig has become Provider-based API

The change summary of this PR

- Added a test case that verifies AndroidStudio 3.6.0-rc01

Notes

- The current HEAD works fine with 3.6.0-beta01 to beta05 but no need to have testcases for acceptance testing because they are *beta*.