### PR TITLE
Fixed AndroidGradlePlugin 4.2.0-alpha14 made breaking changes around PackageApplication#signingConfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands: &commands
               rm sdk-tools.zip
             fi
 
-            yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;29.0.2" "platforms;android-29" "platform-tools" >/dev/null 2>&1 || if [ $? -ne '141' ]; then exit $?; fi;
+            yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;29.0.2" "build-tools;30.0.0" "platforms;android-29" "platform-tools" >/dev/null 2>&1 || if [ $? -ne '141' ]; then exit $?; fi;
       - save_cache:
           paths:
             - ~/android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,10 +168,10 @@ orbs:
             gradle_version: '6.5'
         - acceptance_test:
             agp_version: '4.2.0-alpha13'
-            gradle_version: '6.5'
+            gradle_version: '6.7-rc-4'
         - acceptance_test:
             agp_version: '4.2.0-alpha14'
-            gradle_version: '6.5'
+            gradle_version: '6.7-rc-4'
         - save_gradle_cache:
             prefix: acceptance
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,8 +167,11 @@ orbs:
             agp_version: '4.1.0'
             gradle_version: '6.5'
         - acceptance_test:
-            agp_version: '4.2.0-alpha01'
-            gradle_version: '6.5-rc-1'
+            agp_version: '4.2.0-alpha13'
+            gradle_version: '6.5'
+        - acceptance_test:
+            agp_version: '4.2.0-alpha14'
+            gradle_version: '6.5'
         - save_gradle_cache:
             prefix: acceptance
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands: &commands
               rm sdk-tools.zip
             fi
 
-            yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;29.0.2" "build-tools;30.0.0" "platforms;android-29" "platform-tools" >/dev/null 2>&1 || if [ $? -ne '141' ]; then exit $?; fi;
+            yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;29.0.2" "build-tools;30.0.0" "build-tools;30.0.2" "platforms;android-29" "platform-tools" >/dev/null 2>&1 || if [ $? -ne '141' ]; then exit $?; fi;
       - save_cache:
           paths:
             - ~/android

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 ext {
     agpVersion = '3.3.2'
-    unstableAgpVersion = '4.2.0-alpha01'
+    unstableAgpVersion = '4.2.0-alpha14'
 }
 
 sourceSets {

--- a/run_acceptance_tests.bash
+++ b/run_acceptance_tests.bash
@@ -17,6 +17,7 @@ done < <(cat<<EOF
 3.6.0 5.6.4 false false
 4.0.0 6.1.1 false false
 4.1.0 6.5 false false
-4.2.0-alpha01 6.5-rc-1 false false
+4.2.0-alpha13 6.5 false false
+4.2.0-alpha14 6.5 false false
 EOF
 )

--- a/run_acceptance_tests.bash
+++ b/run_acceptance_tests.bash
@@ -17,7 +17,7 @@ done < <(cat<<EOF
 3.6.0 5.6.4 false false
 4.0.0 6.1.1 false false
 4.1.0 6.5 false false
-4.2.0-alpha13 6.5 false false
-4.2.0-alpha14 6.5 false false
+4.2.0-alpha13 6.7-rc-4 false false
+4.2.0-alpha14 6.7-rc-4 false false
 EOF
 )

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
@@ -49,7 +49,6 @@ class PackageAppTaskCompat {
     @PackageScope
     static boolean hasSigningConfig(packageAppTask) {
         if (!AndroidGradlePlugin.isSigningConfigCollectionSupported()) {
-            packageAppTask.signingConfigData
             return packageAppTask.signingConfig != null
         } else if (!AndroidGradlePlugin.isSigningConfigProviderSupported()) {
             return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.isEmpty()

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
@@ -49,11 +49,14 @@ class PackageAppTaskCompat {
     @PackageScope
     static boolean hasSigningConfig(packageAppTask) {
         if (!AndroidGradlePlugin.isSigningConfigCollectionSupported()) {
+            packageAppTask.signingConfigData
             return packageAppTask.signingConfig != null
         } else if (!AndroidGradlePlugin.isSigningConfigProviderSupported()) {
             return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.isEmpty()
-        } else {
+        } else if (!AndroidGradlePlugin.isResolvableSigningConfigProviderSupported()) {
             return packageAppTask.signingConfig != null && !packageAppTask.signingConfig.signingConfigFileCollection // no need to check `empty` for now
+        } else {
+            return packageAppTask.signingConfigData.resolve() != null
         }
     }
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/VersionString.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/VersionString.groovy
@@ -1,14 +1,22 @@
 package com.deploygate.gradle.plugins.internal
 
+import org.jetbrains.annotations.NotNull
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import javax.annotation.Nullable
 import java.util.regex.Pattern
 
-class VersionString {
+class VersionString implements Comparable<VersionString> {
     private static final Logger LOGGER = LoggerFactory.getLogger(this.getClass())
     private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)(?:\\.(\\d+))?\$")
+    private static final Pattern PRERELEASE_TAG_PATTERN = Pattern.compile("^([a-zA-Z]+).*\$")
+    private static final Map<String, Integer> PRERELEASE_DELTAS = [
+            "alpha": 1,
+            "beta": 2,
+            "rc": 3,
+            "": 100
+    ]
 
     @Nullable
     static VersionString tryParse(@Nullable String version) {
@@ -21,27 +29,35 @@ class VersionString {
         def versions = version.split("-", 2)
 
         try {
-            def matcher = VERSION_PATTERN.matcher(versions[0])
+            def versionMatcher = VERSION_PATTERN.matcher(versions[0])
 
-            if (!matcher.find() || matcher.groupCount() < 2) {
+            if (!versionMatcher.find() || versionMatcher.groupCount() < 2) {
                 return null
             }
 
-            def major = matcher.group(1).toInteger()
-            def minor = matcher.group(2).toInteger()
+            def major = versionMatcher.group(1).toInteger()
+            def minor = versionMatcher.group(2).toInteger()
             def patch = 0
 
-            if (matcher.groupCount() >= 3) {
-                patch = matcher.group(3)?.toInteger() ?: 0
+            if (versionMatcher.groupCount() >= 3) {
+                patch = versionMatcher.group(3)?.toInteger() ?: 0
             }
 
-            String addition = null
+            String prerelease = null
+            int metaBuild = 0
 
             if (versions.length == 2) {
-                addition = versions[1]
+                def prereleaseMatcher = PRERELEASE_TAG_PATTERN.matcher(versions[1])
+                if (!prereleaseMatcher.find() || prereleaseMatcher.groupCount() < 1) {
+                    return null
+                }
+
+                prerelease = prereleaseMatcher.group(1)
+                def meta = versions[1].substring(prerelease.length(), versions[1].length())
+                metaBuild = meta.length() > 0 ? Math.abs(meta.toInteger()) : 0
             }
 
-            new VersionString(major, minor, patch, addition)
+            new VersionString(major, minor, patch, prerelease, metaBuild)
         } catch (NumberFormatException ignore) {
             return null
         }
@@ -52,13 +68,29 @@ class VersionString {
     final int patch
 
     @Nullable
-    final String addition
+    final String prerelease
 
-    VersionString(int major, int minor, int patch, @Nullable String addition) {
+    final int metaBuild
+
+    VersionString(int major, int minor, int patch, @Nullable String prerelease, int metaBuild) {
         this.major = major
         this.minor = minor
         this.patch = patch
-        this.addition = addition
+        this.prerelease = prerelease
+        this.metaBuild = metaBuild
+    }
+
+    @Override
+    int compareTo(@NotNull VersionString versionString) {
+        return [
+                major <=> versionString.major,
+                minor <=> versionString.minor,
+                patch <=> versionString.patch,
+                PRERELEASE_DELTAS[prerelease ?: ""] <=> PRERELEASE_DELTAS[versionString.prerelease ?: ""],
+                metaBuild <=> versionString.metaBuild
+        ].find {
+            it != 0
+        } ?: 0
     }
 
     @Override
@@ -71,9 +103,10 @@ class VersionString {
         builder.append(".")
         builder.append(patch)
 
-        if (addition != null) {
+        if (prerelease != null) {
             builder.append("-")
-            builder.append(addition)
+            builder.append(prerelease)
+            builder.append(metaBuild)
         }
 
         return builder.toString()

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
@@ -46,40 +46,39 @@ class AndroidGradlePlugin {
     }
 
     static boolean isAppBundleSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 2
+        return getVersion() >= VersionString.tryParse("3.2.0-alpha1")
     }
 
     static boolean isSigningConfigCollectionSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
+        return getVersion() >= VersionString.tryParse("3.3.0-alpha1")
     }
 
     static boolean isTaskProviderBased() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 3
+        return getVersion() >= VersionString.tryParse("3.3.0-alpha1")
     }
 
     static boolean isAppBundleArchiveNameChanged() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 5
+        return getVersion() >= VersionString.tryParse("3.5.0-alpha1")
     }
 
     static boolean isSigningConfigProviderSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
+        return getVersion() >= VersionString.tryParse("3.6.0-alpha1")
     }
 
     static boolean isOutputDirectoryProviderSupported() {
-        return getVersion().major >= 4 || getVersion().major == 3 && getVersion().minor >= 6
+        return getVersion() >= VersionString.tryParse("3.6.0-alpha1")
     }
 
     static boolean isOutputFilenameDesignChanged() {
-        return getVersion().major >= 4
+        return getVersion() >= VersionString.tryParse("4.0.0-alpha1")
     }
 
     static boolean isNewTransformArtifactAPI() {
-        return getVersion().major >= 4 && getVersion().minor >= 1
+        return getVersion() >= VersionString.tryParse("4.1.0-alpha1")
     }
 
     static boolean isResolvableSigningConfigProviderSupported() {
-        return getVersion().major >= 4 && getVersion().minor >= 2 && getVersion().patch >= 0 &&
-                (getVersion().addition == null || getVersion().addition.toInteger() >= 14)
+        return getVersion() >= VersionString.tryParse("4.2.0-alpha14")
     }
 
     @Nonnull

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
@@ -77,6 +77,11 @@ class AndroidGradlePlugin {
         return getVersion().major >= 4 && getVersion().minor >= 1
     }
 
+    static boolean isResolvableSigningConfigProviderSupported() {
+        return getVersion().major >= 4 && getVersion().minor >= 2 && getVersion().patch >= 0 &&
+                (getVersion().addition == null || getVersion().addition.toInteger() >= 14)
+    }
+
     @Nonnull
     static String androidAssembleTaskName(@Nonnull String variantName) {
         return "assemble${variantName.capitalize()}"

--- a/src/test/groovy/com/deploygate/gradle/plugins/internal/VersionStringSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/internal/VersionStringSpec.groovy
@@ -36,7 +36,7 @@ class VersionStringSpec extends Specification {
 
         where:
         version          | stringVersion
-        "1.0"            | "1.0"
+        "1.0"            | "1.0.0"
         "1.2.3"          | "1.2.3"
         "1.0.3-extra"    | "1.0.3-extra0"
         "1.0.3-extra03"  | "1.0.3-extra3"
@@ -46,14 +46,14 @@ class VersionStringSpec extends Specification {
     @Unroll
     def "compareTo. Unrolled #version"() {
         given:
-        def lhs = VersionString.tryParse(version)
-        def rhs = VersionString.tryParse(stringVersion)
+        def lhs = VersionString.tryParse(leftVersion)
+        def rhs = VersionString.tryParse(rightVersion)
 
         expect:
         lhs <=> rhs == expected
 
         where:
-        version          | stringVersion  | expected
+        leftVersion      | rightVersion   | expected
         "1.0"            | "1.0"          | 0
         "1.2.1"          | "1.2.3"        | -1
         "1.2.3"          | "1.2.3"        | 0

--- a/src/test/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginSpec.groovy
@@ -55,7 +55,8 @@ class AndroidGradlePluginSpec extends Specification {
         "3.4.0"                    | true                 | true                               | true
         "4.0.0"                    | true                 | true                               | true
         "4.1.0"                    | true                 | true                               | true
-        "4.2.0-alpha01"            | true                 | true                               | true
+        "4.2.0-alpha13"            | true                 | true                               | true
+        "4.2.0-alpha14"            | true                 | true                               | true
         "${Integer.MAX_VALUE}.0.0" | true                 | true                               | true // fallback
     }
 }

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
@@ -68,7 +68,7 @@ class AndroidGradlePluginAcceptanceSpec extends Specification {
         "3.6.0"          | "5.6.4"
         "4.0.0"          | "6.1.1"
         "4.1.0"          | "6.5"
-        "4.2.0-alpha13"  | "6.5"
-        "4.2.0-alpha14"  | "6.5"
+        "4.2.0-alpha13"  | "6.7-rc-4"
+        "4.2.0-alpha14"  | "6.7-rc-4"
     }
 }

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
@@ -68,6 +68,7 @@ class AndroidGradlePluginAcceptanceSpec extends Specification {
         "3.6.0"          | "5.6.4"
         "4.0.0"          | "6.1.1"
         "4.1.0"          | "6.5"
-        "4.2.0-alpha01"  | "6.5-rc-1"
+        "4.2.0-alpha13"  | "6.5"
+        "4.2.0-alpha14"  | "6.5"
     }
 }


### PR DESCRIPTION
SigningConfigData has been introduced since alpha14, and `signingConfig` has been deleted instead.