### PR TITLE
Compatibility with Gradle 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,9 @@ orbs:
         - acceptance_test:
             agp_version: '4.2.0-beta04'
             gradle_version: '6.7.1'
+        - acceptance_test:
+            agp_version: '4.2.0-beta04'
+            gradle_version: '7.0'
         - save_gradle_cache:
             prefix: acceptance
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.groovy
@@ -9,6 +9,7 @@ import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import groovyx.net.http.ContentType
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 import java.util.concurrent.CountDownLatch
@@ -16,11 +17,11 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 class LoginTask extends DefaultTask {
-    def port = 0
+    @Internal def port = 0
 
-    CountDownLatch latch
+    @Internal CountDownLatch latch
     boolean saved
-    CliCredentialStore localCredential
+    @Internal CliCredentialStore localCredential
 
     @TaskAction
     def setup() {
@@ -46,6 +47,13 @@ class LoginTask extends DefaultTask {
     boolean hasCredentialInEnv() {
         [System.getenv(DeployGatePlugin.ENV_NAME_APP_OWNER_NAME), System.getenv(DeployGatePlugin.ENV_NAME_APP_OWNER_NAME_V1)].any() &&
                 [System.getenv(DeployGatePlugin.ENV_NAME_API_TOKEN)].any()
+    }
+
+    // From Gradle 7.0, only one method to get boolean property value is allowed
+    // whereas Groovy generates both isSaved() and getSaved(), Gradle 7.0 considers 2 getters exist for saved property.
+    // To suppress getSaved() we explicitly define isSaved().
+    private boolean isSaved() {
+        saved
     }
 
     private boolean hasSavedCredential() {

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
@@ -65,9 +65,11 @@ abstract class UploadArtifactTask extends DefaultTask {
         )
     }
 
+    @Internal
     @Nullable
     private String variantName
 
+    @Internal
     Configuration configuration
 
     private def lazyPackageApplication

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
@@ -55,7 +55,8 @@ class GradleCompatAcceptanceSpec extends Specification {
                 "5.1.1",
                 "5.4.1",
                 "5.6.4",
-                "6.1.1"
+                "6.1.1",
+                "7.0"
         ]
     }
 }


### PR DESCRIPTION
Starting from Gradle 7.0, we need to explicitly annotate the properties with `@Input`, `@Output` or `@Internal`. Also only one getter method is allowed for a property whereas Groovy generates 2 getters (`isXXX()` and `getXXX()`) for boolean property.

This pull request adds annotations (`LoginTask` and `UploadArtifactTask` properties are not for inputs or outputs so I annotated with `@Internal`) and suppress generating `getXXX()` for boolean property by having `isXXX()` method explicitly.

see also:
1. Missing annotation: https://docs.gradle.org/7.0/userguide/validation_problems.html#missing_annotation
2. Redundant getters: https://docs.gradle.org/7.0/userguide/validation_problems.html#redundant_getters