### PR TITLE
SDKManager requires Java 11 or higher

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -10,9 +10,14 @@ runs:
   steps:
     - uses: actions/setup-java@v3
       with:
-        java-version: ${{ inputs.java-version }}
+        java-version: 11 # for sdkmanager
         distribution: 'temurin'
         cache: 'gradle'
     - uses: android-actions/setup-android@v2
     - run: sdkmanager "build-tools;29.0.2" "build-tools;30.0.0" "build-tools;30.0.2" "platforms;android-29" "platform-tools" ${{ inputs.android-components }}
       shell: bash
+    - uses: actions/setup-java@v3
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'temurin'
+        cache: 'gradle'


### PR DESCRIPTION
This PR allows to set up Java11 before configuring Android SDK