### PR TITLE
Remove the legacy Gradle build lifecycle API

### DIFF
--- a/src/main/groovy/com/deploygate/gradle/plugins/DeployGatePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/DeployGatePlugin.groovy
@@ -61,10 +61,6 @@ class DeployGatePlugin implements Plugin<Project> {
     }
 
     private void onProjectEvaluated(Project project) {
-        project.gradle.buildFinished { buildResult ->
-            project.deploygate.notifyServer('finished', [result: Boolean.toString(buildResult.failure == null)])
-        }
-
         processor.registerLoginTask()
         processor.registerLogoutTask()
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/DeployGateExtension.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/DeployGateExtension.groovy
@@ -150,9 +150,16 @@ class DeployGateExtension implements ExtensionSyntax {
         return deployment
     }
 
-    def notifyServer(String action, HashMap<String, String> data = null) {
+    /**
+     * Notify the plugin's action to the server. Never throw any exception.
+     *
+     * @param action an action name in plugin lifecycle.
+     * @param data a map of key-values
+     * @return true if the request has been processed regardless of its result, otherwise false.
+     */
+    boolean notifyServer(String action, HashMap<String, String> data = null) {
         if (!notifyKey) {
-            return
+            return false
         }
 
         def request = new NotifyActionRequest(notifyKey, action)
@@ -167,5 +174,7 @@ class DeployGateExtension implements ExtensionSyntax {
             ApiClient.getInstance().notify(request)
         } catch (Throwable ignore) {
         }
+
+        return true
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ApiClient.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ApiClient.java
@@ -116,6 +116,16 @@ public class ApiClient {
                 build();
     }
 
+    /**
+     * Upload the application file to the app owner space
+     *
+     * @param appOwnerName an app owner name
+     * @param apiToken an authorization token
+     * @param request a request to the server that must contain a file
+     * @return a successful response that contains a typed json.
+     * @throws HttpResponseException is thrown if a request is an error inclduing 4xx and 5xx
+     * @throws NetworkFailure is thrown if a network trouble happens
+     */
     @SuppressWarnings("RedundantThrows")
     @NotNull
     public Response<UploadAppResponse> uploadApp(@NotNull String appOwnerName, @NotNull String apiToken, @NotNull UploadAppRequest request) throws HttpResponseException, NetworkFailure {
@@ -132,6 +142,13 @@ public class ApiClient {
         }
     }
 
+    /**
+     * Notify the plugin event to the server
+     *
+     * @param request a request to the server that must contain an action name
+     * @throws HttpResponseException is thrown if a request is an error inclduing 4xx and 5xx
+     * @throws NetworkFailure is thrown if a network trouble happens
+     */
     @SuppressWarnings("RedundantThrows")
     public void notify(@NotNull NotifyActionRequest request) throws HttpResponseException, NetworkFailure {
         HttpPost httpPost = new HttpPost(endpoint + "/cli/notify");
@@ -146,6 +163,13 @@ public class ApiClient {
         }
     }
 
+    /**
+     * Get the credentials from the server
+     *
+     * @param notifyKey a notification key. In general, this is generated in the authentication flow.
+     * @throws HttpResponseException is thrown if a request is an error inclduing 4xx and 5xx
+     * @throws NetworkFailure is thrown if a network trouble happens
+     */
     @NotNull
     public Response<GetCredentialsResponse> getCredentials(@NotNull String notifyKey) throws HttpResponseException, NetworkFailure {
         URI uri;

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
@@ -116,12 +116,9 @@ abstract class UploadArtifactTask extends DefaultTask {
             if (!sent && (Config.shouldOpenAppDetailAfterUpload() || response.typedResponse.application.revision == 1)) {
                 BrowserUtils.openBrowser "${project.deploygate.endpoint}${response.typedResponse.application.path}"
             }
-        } catch (HttpResponseException e) {
+        } catch (Throwable e) {
             logger.debug(e.message, e)
             project.deploygate.notifyServer 'upload_finished', ['error': true, message: e.message]
-            throw new GradleException("${variantName} failed due to: ${e.message}", e)
-        } catch (NetworkFailure e) {
-            logger.debug(e.message, e)
             throw new GradleException("${variantName} failed due to ${e.message}", e)
         }
     }


### PR DESCRIPTION
Related to #147 and #148

As for buildFinished, we have not used this action for a while. We can safely delete this.