### PR TITLE
Add Gradle 8.x and Flamingo tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,7 +97,7 @@ jobs:
           - '7.2.0'
           - '7.3.0'
           - '7.4.0'
-          - '8.0.0-alpha10'
+          - '8.0.0-beta04'
         include:
           - agp_version: '3.5.1'
             gradle_version: '5.4.1'
@@ -132,10 +132,10 @@ jobs:
           - agp_version: '7.4.0'
             gradle_version: '7.5'
             java_version: '11'
-          - agp_version: '8.0.0-alpha10'
-            gradle_version: '7.5'
+          - agp_version: '8.0.0-beta04'
+            gradle_version: '8.0.0'
             java_version: '17'
-            runner_gradle_version: '7.3'
+            runner_gradle_version: '8.0.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,9 +133,9 @@ jobs:
             gradle_version: '7.5'
             java_version: '11'
           - agp_version: '8.0.0-beta04'
-            gradle_version: '8.0.0'
+            gradle_version: '8.0'
             java_version: '17'
-            runner_gradle_version: '8.0.0'
+            runner_gradle_version: '8.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -85,8 +85,9 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group = 'com.deploygate'
-archivesBaseName = 'gradle'
 version = new File(rootProject.projectDir, 'src/main/resources/VERSION').text.trim()
+
+def archivesBaseName = 'gradle'
 
 repositories {
     google()
@@ -217,13 +218,13 @@ project.tasks.withType(Test).configureEach {
 }
 
 task javadocJar(type: Jar, dependsOn: groovydoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from "${buildDir}/javadoc"
 }
 
 task sourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
-    classifier = 'sources'
 }
 
 def getRepositoryUsername() {
@@ -257,7 +258,7 @@ afterEvaluate {
                 artifact sourcesJar
                 artifact javadocJar
                 groupId = project.group
-                artifactId = project.archivesBaseName
+                artifactId = archivesBaseName
                 version = project.version
                 pom {
                     name = "Gradle DeployGate Plugin"

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
@@ -74,7 +74,7 @@ class GradleCompatAcceptanceSpec extends Specification {
 
         where:
         gradleVersion << [
-                "8.0.0"
+                "8.0"
         ]
     }
 }


### PR DESCRIPTION
We have to chose the proper test cases depending on JRE versions because JDK17 cannot execute Gradle <7.3. 
