### PR TITLE
Use Spotless to format source codes

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,9 +1,10 @@
 name: 'Set up Java'
 inputs:
   java-version:
-    default: '8'
+    description: JRE version to run tasks
     required: false
   android-components:
+    description: Additional Android components to install
     required: false
 runs:
   using: 'composite'
@@ -16,7 +17,9 @@ runs:
     - uses: android-actions/setup-android@v2
     - run: sdkmanager "build-tools;29.0.2" "build-tools;30.0.0" "build-tools;30.0.2" "platforms;android-29" "platform-tools" ${{ inputs.android-components }}
       shell: bash
-    - uses: actions/setup-java@v3
+    - if: >
+        inputs.java-version
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-java
-        with:
-          java-version: '8'
       - run: ./gradlew spotlessCheck
 
   unit-test:
@@ -32,8 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-java
-        with:
-          java-version: '8'
       - run: ./gradlew publishToMavenLocal test
         env:
           TEST_SERVER_URL: http://localhost:${{ job.services.app.ports[3000] }}
@@ -64,8 +60,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-java
-        with:
-          java-version: '8'
       - run: ./gradlew testUnrollAcceptanceTest
         env:
           TEST_SERVER_URL: http://localhost:3000
@@ -106,25 +100,18 @@ jobs:
         include:
           - agp_version: '4.2.0'
             gradle_version: '6.7.1'
-            java_version: '8'
           - agp_version: '4.2.0'
             gradle_version: '7.0.2'
-            java_version: '8'
           - agp_version: '7.0.0'
             gradle_version: '7.0.2'
-            java_version: '11'
           - agp_version: '7.1.0'
             gradle_version: '7.2'
-            java_version: '11'
           - agp_version: '7.2.0'
             gradle_version: '7.3.3'
-            java_version: '11'
           - agp_version: '7.3.0'
             gradle_version: '7.4.2'
-            java_version: '11'
           - agp_version: '7.4.0'
             gradle_version: '7.5'
-            java_version: '11'
           - agp_version: '8.0.0-beta04'
             gradle_version: '8.0'
             java_version: '17'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,8 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: master # for ratchet
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-java
-      - run: ./gradlew spotlessCheck
+      - run: ./gradlew spotlessApply
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: spotless
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,15 @@ on:
       - master
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-java
+        with:
+          java-version: '8'
+      - run: ./gradlew spotlessCheck
+
   unit-test:
     runs-on: ubuntu-latest
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 This version also includes
 
 - Several improvements for developers' support.
-- Arctic Fox, Bumblebee, Chipmunk supports.  
+- Arctic Fox, Bumblebee, Chipmunk supports.
 
 ## ver 2.4.0
 
@@ -42,7 +42,7 @@ Includes changes to support Android Studio 4.1.0-beta01, 4.2.0-alpha01 [#106](ht
 - Change the DSL syntax
 - Change environment variable names
 - Support Android Studio 3.3.0 and higher
-- Avoid using obsoleted apis of Android Plugin for Gradle whose version is lower than 3.4.0-beta04 
+- Avoid using obsoleted apis of Android Plugin for Gradle whose version is lower than 3.4.0-beta04
 
 *Breaking changes*
 
@@ -79,7 +79,7 @@ Deprecated | New
 
 ## ver 1.1.3
 
- * Restore auto configuring APK file path functionality (supports Android Gradle Plugin 3.0.0-alpha4) 
+ * Restore auto configuring APK file path functionality (supports Android Gradle Plugin 3.0.0-alpha4)
 
 ## ver 1.1.2
 
@@ -88,7 +88,7 @@ Deprecated | New
 ## ver 1.1.1
 
  * Workaround for the issue on Android Gradle Plugin 3.0 Preview
-    * You need to specify the `sourceFile` option manually in your build.gradle to upload builds. This temporal limitation will be resolved in future release of Android Gradle Plugin. 
+    * You need to specify the `sourceFile` option manually in your build.gradle to upload builds. This temporal limitation will be resolved in future release of Android Gradle Plugin.
 
 ## ver 1.1.0
 
@@ -113,5 +113,5 @@ Deprecated | New
 
 ## ver 1.0.0
 
- * Support browser log in and share credentials with `dg` command. 
+ * Support browser log in and share credentials with `dg` command.
  * DeployGate plugin now handles all Android project automatically, so you don't have to write `deploygate` settings to your `build.gradle`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pluginManagement {
 2 ) Apply this plugin to your app module
 
 ```groovy
-apply plugin: 'com.android.application' // It's better to apply Android Plugin for Gradle first. 
+apply plugin: 'com.android.application' // It's better to apply Android Plugin for Gradle first.
 apply plugin: 'deploygate'
 ```
 
@@ -64,10 +64,10 @@ plugins {
 This plugin does not work with non-app modules and/or library modules correctly.
 
 3 ) Ready for deployments. Run tasks which you need. Please check the *Usage#Tasks* section for the detail of added tasks.
- 
+
 ### If you are using `dg` command (for MacOSX)
 
-[dg](https://github.com/deploygate/deploygate-cli) will make diffs to apply this plugin if you run `dg deploy` on the project root. 
+[dg](https://github.com/deploygate/deploygate-cli) will make diffs to apply this plugin if you run `dg deploy` on the project root.
 
 ## Version Compatibility
 
@@ -123,7 +123,7 @@ See the test matrix of [.github/workflows/build-and-test.yml](./.github/workflow
 
 #### loginDeployGate
 
-This task reads stored and/or specified credentials. 
+This task reads stored and/or specified credentials.
 If no credentials are found, this requests you to log in to DeployGate and save credentials to your local.
 
 #### logoutDeployGate
@@ -156,10 +156,10 @@ deploygate {
 
 ## How configure your deployments
 
-*v2* has changed the DSL. See [Migrate from v1 to v2](#migrate-v2) for more detail. 
+*v2* has changed the DSL. See [Migrate from v1 to v2](#migrate-v2) for more detail.
 
 ```groovy
-apply plugin: 'deploygate'                    // add this *after* 'android' plugin 
+apply plugin: 'deploygate'                    // add this *after* 'android' plugin
 
 // Optional configuration
 deploygate {
@@ -170,9 +170,9 @@ deploygate {
 
   // You can also specify additional configurations for each variants.
   deployments {
-    
+
     // This corresponds to `flavor1` product flavor and `debug` buildType
-    // This configuration will be used for `uploadDeployGateFlavor1Debug` task 
+    // This configuration will be used for `uploadDeployGateFlavor1Debug` task
     flavor1Debug {
       // ProTip: Use Git hash of the current commit for easier troubleshooting
       def hash = "git rev-parse --short HEAD".execute([], project.rootDir).in.text.trim()
@@ -182,7 +182,7 @@ deploygate {
 
       // `uploadDeployGateFlavor1Debug` will skip running `assembleFlavor1Debug` if this property is `true`.
       skipAssemble = true // false by default
-      
+
       // This property is basically optional.
       // Because this plugin will set the apk path automatically if you would like to upload a build artifact of this variant
       sourceFile = file("${project.rootDir}/app/build/outputs/apk/manual-manipulate/app-signed.apk")
@@ -190,18 +190,18 @@ deploygate {
       // You can update a distribution as well. This configuration is optional.
       // Known limitation: *name* is not supported, so this plugin cannot create a new distribution.
       distribution {
-          // A key of an existing distribution 
+          // A key of an existing distribution
           key = "1234567890abcdef1234567890abcdef"
           // A release note of a distribution which is associated with this build
           releaseNote = "release note sample"
       }
-      
+
       // If you are using KotlinDSL
       distribution(closureOf<com.deploygate.gradle.plugins.dsl.Distribution> {
           ...
       })
     }
-    
+
     // You can define any names which you would like to use.
     // In this case, this plugin creates `uploadDeployGateUniversalApkOfAab` task to upload the specified apk file.
     universalApkOfAab {
@@ -225,7 +225,7 @@ You can configure this plugin as well by providing environment variables. This w
  * `DEPLOYGATE_DISTRIBUTION_KEY`
  * `DEPLOYGATE_DISTRIBUTION_RELEASE_NOTE`
  * `DEPLOYGATE_SOURCE_FILE`
- * `DEPLOYGATE_OPEN_BROWSER` (Env only; open the app page after the uploading finished) 
+ * `DEPLOYGATE_OPEN_BROWSER` (Env only; open the app page after the uploading finished)
 
 Environment variable configurations allow you to avoid writing your credentials directly in the code.
 
@@ -277,6 +277,13 @@ If you get a time-out error from jitpack, then please run your task again.
 
 ## Development
 
+### Requirements
+
+- JRE 11+
+- Docker (only for testing)
+
+### Steps
+
 You can try this plugin locally by following the steps below.
 
 0. Clone this repository
@@ -285,10 +292,10 @@ You can try this plugin locally by following the steps below.
 3. Add mavenLocal to buildscript repository of a test project
 4. Specify the version which you specify at step 1
 
-And also, please make sure your changes pass unit tests and acceptance tests.  
+And also, please make sure your changes pass unit tests and acceptance tests.
 
 ```bash
-# please make sure the mock server has been launched 
+# please make sure the mock server has been launched
 docker compose build
 docker compose up -d
 
@@ -312,9 +319,9 @@ Deprecated | New
 
 *If both of v1 and v2 variables are specified, v2 variables will be used.*
 
-**v2.0.x can use the v1 syntax as it is, but we will start to make it obsolete from v2.1.0**  
+**v2.0.x can use the v1 syntax as it is, but we will start to make it obsolete from v2.1.0**
 
-Let's say we have a v1 configuration like below. 
+Let's say we have a v1 configuration like below.
 
 ```groovy
 deploygate {

--- a/README_JP.md
+++ b/README_JP.md
@@ -152,7 +152,7 @@ deploygate {
 
 ## デプロイの設定方法
 
-*v2* では設定 DSL を変更しています。その変更については [v1 から v2 への移行](#migrate-v2) を参照してください。 
+*v2* では設定 DSL を変更しています。その変更については [v1 から v2 への移行](#migrate-v2) を参照してください。
 
 ```groovy
 apply plugin: 'deploygate' // android plugin のあとに記述してください
@@ -166,7 +166,7 @@ deploygate {
 
   // 各 Variant についてのデプロイ設定をここに記述します。
   deployments {
-    
+
     // `flavor1` product flavor と `debug` buildType への設定です。
     // `uploadDeployGateFlavor1Debug` タスクがこの設定に基づいて動作します。
     flavor1Debug {
@@ -178,7 +178,7 @@ deploygate {
 
       // このフラグが true の場合、`assembleFlavor1Debug` は実行されません。
       skipAssemble = true // デフォルトは false です。
-      
+
       // product flavor と build type に関連付けられた設定の場合、基本的に指定する必要はありません。
       // プラグインは flavor1Debug の apk 保存先を自動で読み取ります。
       sourceFile = file("${project.rootDir}/app/build/outputs/apk/manual-manipulate/app-signed.apk")
@@ -191,13 +191,13 @@ deploygate {
           // この配布ページに載せるリリースノートを指定できます。上記の key が設定されていない場合は利用されません。
           releaseNote = "release note sample"
       }
-      
+
       // KotlinDSL を利用している場合は以下の記述をお使いください。
       distribution(closureOf<com.deploygate.gradle.plugins.dsl.Distribution> {
           ...
       })
     }
-    
+
     // 任意の名前を設定することも可能です。
     // この設定だと `uploadDeployGateUniversalApkOfAab` タスクが生成されます。
     universalApkOfAab {
@@ -221,7 +221,7 @@ deploygate {
  * `DEPLOYGATE_DISTRIBUTION_KEY`
  * `DEPLOYGATE_DISTRIBUTION_RELEASE_NOTE`
  * `DEPLOYGATE_SOURCE_FILE`
- * `DEPLOYGATE_OPEN_BROWSER` - 環境変数からのみ設定可能。 アップロードが終わり次第ブラウザを開くかどうかが設定できます 
+ * `DEPLOYGATE_OPEN_BROWSER` - 環境変数からのみ設定可能。 アップロードが終わり次第ブラウザを開くかどうかが設定できます
 
 *環境変数経由であれば、認証情報を直接 build.gradle に記述することなく設定できます。*
 
@@ -271,6 +271,13 @@ jitpack.io は初回のリクエストを受けてからスナップショット
 
 ## 開発
 
+### 要求
+
+- JRE 11+
+- Docker (テスト用の機能のみ)
+
+### Steps
+
 下記のステップでローカルでプラグインを試すことができます。
 
 0. リポジトリのクローン
@@ -282,7 +289,7 @@ jitpack.io は初回のリクエストを受けてからスナップショット
 また変更したあとはユニットテストと受け入れテストが通ることを確認してください。
 
 ```bash
-# Mock サーバーを起動させてください 
+# Mock サーバーを起動させてください
 docker compose build
 docker compose up -d
 
@@ -306,7 +313,7 @@ docker compose up -d
 
 *非推奨となった記述と新しい記述が混在する場合、新しい記述が基本的には優先されます。*
 
-**バージョン 2.0.x は v1 の記法をそのまま利用できます。バージョン2.1.0 より、非推奨となった記法を削除していきます。**  
+**バージョン 2.0.x は v1 の記法をそのまま利用できます。バージョン2.1.0 より、非推奨となった記法を削除していきます。**
 
 以下の v1 の設定に対して、v2 への移行を行います。
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,13 @@ import java.util.regex.Pattern
 
 buildscript {
     repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
         mavenCentral()
+    }
+    dependencies {
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.13.0"
     }
 }
 
@@ -83,6 +89,7 @@ class VersionString implements Comparable<VersionString> {
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: "com.diffplug.spotless"
 
 group = 'com.deploygate'
 version = new File(rootProject.projectDir, 'src/main/resources/VERSION').text.trim()
@@ -237,6 +244,37 @@ def getRepositoryPassword() {
 
 def isRelease() {
     return rootProject.ext.releaseVersion =~ /^\d+\.\d+\.\d+$/
+}
+
+allprojects {
+    spotless {
+        ratchetFrom 'origin/master'
+
+        encoding 'UTF-8'
+
+        java {
+            importOrder()
+            removeUnusedImports()
+            googleJavaFormat('1.16.0').aosp().reflowLongStrings()
+            formatAnnotations()
+        }
+        groovy {
+            importOrder()
+            excludeJava()
+            greclipse('4.8.0')
+        }
+        groovyGradle {
+            target '*.gradle'
+            greclipse('4.8.0')
+        }
+        format 'misc', {
+            target '*.md', '.gitignore', '*.properties'
+
+            trimTrailingWhitespace()
+            indentWithSpaces()
+            endWithNewline()
+        }
+    }
 }
 
 afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,10 @@ allprojects {
             indentWithSpaces(4)
             endWithNewline()
         }
+
+        // TODO detect violations automatically
+        // DO: Use org.jetbrains.annotations.{NotNull,Nullable,VisibleForTesting}
+        // DON'T: Use javax.annotations.{Nonnull,Nullable}, Guavas VisibleForTesting
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,10 @@ import java.util.regex.Pattern
 
 buildscript {
     repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        maven { url "https://plugins.gradle.org/m2/" }
         mavenCentral()
     }
-    dependencies {
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.13.0"
-    }
+    dependencies { classpath "com.diffplug.spotless:spotless-plugin-gradle:6.13.0" }
 }
 
 class VersionString implements Comparable<VersionString> {
@@ -154,7 +150,7 @@ task createClasspathManifest {
 if (requireJava11) {
     // since this version, android gradle plugin artifact is targeting Java 11 and we are using it in testing dependencies.
     // We need to change target compatibility only for testing.
-    sourceCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_11
 } else {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -165,8 +161,8 @@ dependencies {
     compileOnly gradleApi()
     compileOnly localGroovy()
     // Don't enable this on the repository because this artifact may include bytecode incompatibility.
-//    compileOnly "com.android.tools.build:gradle:$androidGradleVersion"
-    implementation 'org.jetbrains:annotations:23.1.0'
+    //    compileOnly "com.android.tools.build:gradle:$androidGradleVersion"
+    implementation 'org.jetbrains:annotations:24.0.1'
     implementation 'com.google.guava:guava-annotations:r03'
 
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
@@ -217,10 +213,10 @@ project.tasks.withType(Test).configureEach {
     }
 
     environment([
-            "ANDROID_HOME": System.getenv("ANDROID_HOME"),
-            "TEST_AGP_VERSION": System.getenv("TEST_AGP_VERSION"),
-            "TEST_GRADLE_VERSION": System.getenv("TEST_GRADLE_VERSION"),
-            "TEST_SERVER_URL": System.getenv("TEST_SERVER_URL") ?: "http://localhost:3000",
+        "ANDROID_HOME": System.getenv("ANDROID_HOME"),
+        "TEST_AGP_VERSION": System.getenv("TEST_AGP_VERSION"),
+        "TEST_GRADLE_VERSION": System.getenv("TEST_GRADLE_VERSION"),
+        "TEST_SERVER_URL": System.getenv("TEST_SERVER_URL") ?: "http://localhost:3000",
     ])
 }
 
@@ -247,6 +243,7 @@ def isRelease() {
 }
 
 allprojects {
+    // spotless requires Java11 so please comment out all spotless configurations if you wanna run on JRE 8
     spotless {
         ratchetFrom 'origin/master'
 
@@ -257,21 +254,24 @@ allprojects {
             removeUnusedImports()
             googleJavaFormat('1.16.0').aosp().reflowLongStrings()
             formatAnnotations()
+            indentWithSpaces(4)
         }
         groovy {
             importOrder()
             excludeJava()
             greclipse('4.8.0')
+            indentWithSpaces(4)
         }
         groovyGradle {
             target '*.gradle'
             greclipse('4.8.0')
+            indentWithSpaces(4)
         }
         format 'misc', {
             target '*.md', '.gitignore', '*.properties'
 
             trimTrailingWhitespace()
-            indentWithSpaces()
+            indentWithSpaces(4)
             endWithNewline()
         }
     }
@@ -315,9 +315,7 @@ afterEvaluate {
                             name = "DeployGate"
                         }
                     }
-                    scm {
-                        url = 'https://github.com/DeployGate/gradle-deploygate-plugin'
-                    }
+                    scm { url = 'https://github.com/DeployGate/gradle-deploygate-plugin' }
                 }
             }
         }
@@ -328,9 +326,7 @@ afterEvaluate {
             def signingKey = findProperty("signingKey")
             def signingPassword = findProperty("signingPassword")
             useInMemoryPgpKeys(signingKey, signingPassword)
-            publishing.publications.configureEach { publication ->
-                sign publication
-            }
+            publishing.publications.configureEach { publication -> sign publication }
         }
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/DeployGatePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/DeployGatePlugin.groovy
@@ -1,13 +1,18 @@
 package com.deploygate.gradle.plugins
 
+import static com.deploygate.gradle.plugins.artifacts.PackageAppTaskCompat.getAabInfo
+import static com.deploygate.gradle.plugins.artifacts.PackageAppTaskCompat.getApkInfo
+import static com.deploygate.gradle.plugins.internal.agp.AndroidGradlePlugin.androidAssembleTaskName
+import static com.deploygate.gradle.plugins.internal.agp.AndroidGradlePlugin.androidBundleTaskName
+
 import com.deploygate.gradle.plugins.artifacts.DefaultPresetAabInfo
 import com.deploygate.gradle.plugins.artifacts.DefaultPresetApkInfo
-import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.dsl.DeployGateExtension
 import com.deploygate.gradle.plugins.dsl.NamedDeployment
 import com.deploygate.gradle.plugins.internal.DeprecationLogger
 import com.deploygate.gradle.plugins.internal.agp.AndroidGradlePlugin
 import com.deploygate.gradle.plugins.internal.agp.IApplicationVariantImpl
+import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
 import com.deploygate.gradle.plugins.internal.http.HttpClient
 import com.deploygate.gradle.plugins.tasks.Constants
@@ -15,7 +20,6 @@ import com.deploygate.gradle.plugins.tasks.LoginTask
 import com.deploygate.gradle.plugins.tasks.LogoutTask
 import com.deploygate.gradle.plugins.tasks.UploadAabTask
 import com.deploygate.gradle.plugins.tasks.UploadApkTask
-
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
@@ -23,11 +27,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.annotations.NotNull
-
-import static com.deploygate.gradle.plugins.artifacts.PackageAppTaskCompat.getAabInfo
-import static com.deploygate.gradle.plugins.artifacts.PackageAppTaskCompat.getApkInfo
-import static com.deploygate.gradle.plugins.internal.agp.AndroidGradlePlugin.androidAssembleTaskName
-import static com.deploygate.gradle.plugins.internal.agp.AndroidGradlePlugin.androidBundleTaskName
 
 class DeployGatePlugin implements Plugin<Project> {
     private static final String EXTENSION_NAME = 'deploygate'

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/AabInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/AabInfo.groovy
@@ -1,10 +1,10 @@
 package com.deploygate.gradle.plugins.artifacts
 
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 
 interface AabInfo {
-    @Nonnull
+    @NotNull
     String getVariantName()
 
     @Nullable

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/ApkInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/ApkInfo.groovy
@@ -1,10 +1,10 @@
 package com.deploygate.gradle.plugins.artifacts
 
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 
 interface ApkInfo {
-    @Nonnull
+    @NotNull
     String getVariantName()
 
     @Nullable

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DefaultPresetAabInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DefaultPresetAabInfo.groovy
@@ -1,9 +1,9 @@
 package com.deploygate.gradle.plugins.artifacts
 
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 class DefaultPresetAabInfo extends DirectAabInfo {
-    DefaultPresetAabInfo(@Nonnull String variantName) {
+    DefaultPresetAabInfo(@NotNull String variantName) {
         super(variantName, null)
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DefaultPresetApkInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DefaultPresetApkInfo.groovy
@@ -1,9 +1,9 @@
 package com.deploygate.gradle.plugins.artifacts
 
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 class DefaultPresetApkInfo extends DirectApkInfo {
-    DefaultPresetApkInfo(@Nonnull String variantName) {
+    DefaultPresetApkInfo(@NotNull String variantName) {
         super(variantName, null, true, true)
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DirectAabInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DirectAabInfo.groovy
@@ -1,18 +1,17 @@
 package com.deploygate.gradle.plugins.artifacts
 
-import com.google.common.annotations.VisibleForTesting
-
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
+import org.jetbrains.annotations.VisibleForTesting
 
 @VisibleForTesting
 class DirectAabInfo implements AabInfo {
-    @Nonnull
+    @NotNull
     private final String variantName
     @Nullable
     private final File aabFile
 
-    DirectAabInfo(@Nonnull String variantName, @Nullable File aabFile) {
+    DirectAabInfo(@NotNull String variantName, @Nullable File aabFile) {
         this.variantName = variantName
         this.aabFile = aabFile
 
@@ -22,7 +21,7 @@ class DirectAabInfo implements AabInfo {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     String getVariantName() {
         return variantName
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DirectApkInfo.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/DirectApkInfo.groovy
@@ -1,20 +1,19 @@
 package com.deploygate.gradle.plugins.artifacts
 
-import com.google.common.annotations.VisibleForTesting
-
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
+import org.jetbrains.annotations.VisibleForTesting
 
 @VisibleForTesting
 class DirectApkInfo implements ApkInfo {
-    @Nonnull
+    @NotNull
     private final String variantName
     @Nullable
     private final File apkFile
     private final boolean signingReady
     private final boolean universalApk
 
-    DirectApkInfo(@Nonnull String variantName, @Nullable File apkFile, boolean signingReady, boolean universalApk) {
+    DirectApkInfo(@NotNull String variantName, @Nullable File apkFile, boolean signingReady, boolean universalApk) {
         this.variantName = variantName
         this.apkFile = apkFile
         this.signingReady = signingReady
@@ -26,7 +25,7 @@ class DirectApkInfo implements ApkInfo {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     String getVariantName() {
         return variantName
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/artifacts/PackageAppTaskCompat.groovy
@@ -1,15 +1,14 @@
 package com.deploygate.gradle.plugins.artifacts
 
 import groovy.transform.PackageScope
-
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 class PackageAppTaskCompat {
     private PackageAppTaskCompat() {
     }
 
-    @Nonnull
-    static ApkInfo getApkInfo(@Nonnull /* PackageApplication */ packageAppTask, @Nonnull String variantName) {
+    @NotNull
+    static ApkInfo getApkInfo(@NotNull /* PackageApplication */ packageAppTask, @NotNull String variantName) {
         // outputScope is retrieved by the reflection
         Collection<String> apkNames = getApkNames(packageAppTask)
         File outputDir = getOutputDirectory(packageAppTask)
@@ -21,11 +20,11 @@ class PackageAppTaskCompat {
                 new File(outputDir, (String) apkNames[0]),
                 isSigningReady,
                 isUniversal,
-        )
+                )
     }
 
-    @Nonnull
-    static AabInfo getAabInfo(@Nonnull /* PackageApplication */ packageAppTask, @Nonnull String variantName, @Nonnull File buildDir) {
+    @NotNull
+    static AabInfo getAabInfo(@NotNull /* PackageApplication */ packageAppTask, @NotNull String variantName, @NotNull File buildDir) {
         final String aabName
 
         // TODO Use Artifact API
@@ -38,7 +37,7 @@ class PackageAppTaskCompat {
         return new DirectAabInfo(
                 variantName,
                 new File(outputDir, aabName),
-        )
+                )
     }
 
     @PackageScope

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/DeployGateExtension.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/DeployGateExtension.groovy
@@ -1,15 +1,14 @@
 package com.deploygate.gradle.plugins.dsl
 
 import com.deploygate.gradle.plugins.DeployGatePlugin
-import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.dsl.syntax.ExtensionSyntax
 import com.deploygate.gradle.plugins.internal.annotation.DeployGateInternal
+import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.tasks.Internal
-
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 
 class DeployGateExtension implements ExtensionSyntax {
     String apiToken
@@ -19,27 +18,30 @@ class DeployGateExtension implements ExtensionSyntax {
     @Deprecated
     String notifyKey = null
 
-    @Nonnull
+    @NotNull
     private final Project project
 
-    @Nonnull
+    @NotNull
     private final NamedDomainObjectContainer<NamedDeployment> deployments
 
-    @Nonnull
+    @NotNull
     private final CliCredentialStore credentialStore
 
-    DeployGateExtension(@Nonnull Project project, @Nonnull NamedDomainObjectContainer<NamedDeployment> deployments, @Nonnull CliCredentialStore credentialStore) {
+    DeployGateExtension(@NotNull Project project, @NotNull NamedDomainObjectContainer<NamedDeployment> deployments, @NotNull CliCredentialStore credentialStore) {
         this.project = project
         this.deployments = deployments
         this.credentialStore = credentialStore
 
-        this.appOwnerName = [System.getenv(DeployGatePlugin.ENV_NAME_APP_OWNER_NAME), System.getenv(DeployGatePlugin.ENV_NAME_APP_OWNER_NAME_V1), credentialStore.getName()].find {
-            it != null
-        }
+        this.appOwnerName = [
+            System.getenv(DeployGatePlugin.ENV_NAME_APP_OWNER_NAME),
+            System.getenv(DeployGatePlugin.ENV_NAME_APP_OWNER_NAME_V1),
+            credentialStore.getName()
+        ].find { it != null }
 
-        this.apiToken = [System.getenv(DeployGatePlugin.ENV_NAME_API_TOKEN), credentialStore.getToken()].find {
-            it != null
-        }
+        this.apiToken = [
+            System.getenv(DeployGatePlugin.ENV_NAME_API_TOKEN),
+            credentialStore.getToken()
+        ].find { it != null }
     }
 
     // backward compatibility
@@ -84,7 +86,7 @@ class DeployGateExtension implements ExtensionSyntax {
 
     // end: backward compatibility
 
-    @Nonnull
+    @NotNull
     @Override
     NamedDomainObjectContainer<NamedDeployment> getDeployments() {
         return deployments
@@ -95,12 +97,12 @@ class DeployGateExtension implements ExtensionSyntax {
         deployments.configure(closure)
     }
 
-    boolean hasDeployment(@Nonnull String name) {
+    boolean hasDeployment(@NotNull String name) {
         return deployments.findByName(name)
     }
 
     @DeployGateInternal
-    @Nonnull
+    @NotNull
     @Internal
     CliCredentialStore getCredentialStore() {
         return credentialStore

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/Distribution.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/Distribution.groovy
@@ -1,8 +1,7 @@
 package com.deploygate.gradle.plugins.dsl
 
 import com.deploygate.gradle.plugins.dsl.syntax.DistributionSyntax
-
-import javax.annotation.Nullable
+import org.jetbrains.annotations.Nullable
 
 class Distribution implements DistributionSyntax {
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/NamedDeployment.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/NamedDeployment.java
@@ -3,13 +3,12 @@ package com.deploygate.gradle.plugins.dsl;
 import com.deploygate.gradle.plugins.dsl.syntax.DeploymentSyntax;
 import com.deploygate.gradle.plugins.internal.DeprecationLogger;
 import groovy.lang.Closure;
-import org.gradle.api.Action;
-import org.gradle.api.Named;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Objects;
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /*
  * This file cannot be written in Groovy until we decide to drop supporting Gradle 6.7 or lower.
@@ -18,33 +17,27 @@ import java.util.Objects;
  * For the more details, please check https://github.com/DeployGate/gradle-deploygate-plugin/pull/144 out.
  */
 public class NamedDeployment implements Named, DeploymentSyntax {
-    @Nonnull
-    private final String name;
+    @NotNull private final String name;
 
-    @Nullable
-    private File sourceFile;
+    @Nullable private File sourceFile;
 
-    @Nullable
-    private String message;
+    @Nullable private String message;
 
     private boolean skipAssemble;
 
-    @Nullable
-    @Deprecated
-    private String visibility;
+    @Nullable @Deprecated private String visibility;
 
-    // Avoid using Optional like Guava for now because we want to reduce external dependencies as much as possible.
-    @Nonnull
-    private Distribution[] optionalDistribution;
+    // Avoid using Optional like Guava for now because we want to reduce external dependencies as
+    // much as possible.
+    @NotNull private Distribution[] optionalDistribution;
 
-    public NamedDeployment(@Nonnull String name) {
+    public NamedDeployment(@NotNull String name) {
         this.name = name;
-        this.optionalDistribution = new Distribution[]{new Distribution()};
+        this.optionalDistribution = new Distribution[] {new Distribution()};
     }
 
     @Override
-    @Nonnull
-    public String getName() {
+    @NotNull public String getName() {
         return name;
     }
 
@@ -52,9 +45,7 @@ public class NamedDeployment implements Named, DeploymentSyntax {
         return skipAssemble;
     }
 
-    /**
-     * for Kotlin properly access
-     */
+    /** for Kotlin properly access */
     public boolean getSkipAssemble() {
         return skipAssemble;
     }
@@ -64,8 +55,7 @@ public class NamedDeployment implements Named, DeploymentSyntax {
         this.skipAssemble = skipAssemble;
     }
 
-    @Nullable
-    public File getSourceFile() {
+    @Nullable public File getSourceFile() {
         return sourceFile;
     }
 
@@ -74,8 +64,7 @@ public class NamedDeployment implements Named, DeploymentSyntax {
         this.sourceFile = sourceFile;
     }
 
-    @Nullable
-    public String getMessage() {
+    @Nullable public String getMessage() {
         return message;
     }
 
@@ -85,12 +74,12 @@ public class NamedDeployment implements Named, DeploymentSyntax {
     }
 
     @Override
-    public void distribution(@Nonnull Action<Distribution> builder) {
+    public void distribution(@NotNull Action<Distribution> builder) {
         builder.execute(getDistribution());
     }
 
     @Override
-    public void distribution(@Nonnull Closure cl) {
+    public void distribution(@NotNull Closure cl) {
         Distribution distribution = getDistribution();
         cl.setDelegate(distribution);
         cl.setResolveStrategy(Closure.DELEGATE_ONLY);
@@ -101,8 +90,7 @@ public class NamedDeployment implements Named, DeploymentSyntax {
         return getDistribution().isPresent();
     }
 
-    @Nonnull
-    public Distribution getDistribution() {
+    @NotNull public Distribution getDistribution() {
         return optionalDistribution[0];
     }
 
@@ -111,61 +99,92 @@ public class NamedDeployment implements Named, DeploymentSyntax {
     @Override
     @Deprecated
     public void setVisibility(@Nullable String visibility) {
-        DeprecationLogger.deprecation("NamedDeployment.setVisibility(String)", "2.5", "3.0", "This API has no effect and no alternative is available. You would see this message until ${DeployGatePlugin.ENV_NAME_APP_VISIBILITY} environment variable is removed.");
+        DeprecationLogger.deprecation(
+                "NamedDeployment.setVisibility(String)",
+                "2.5",
+                "3.0",
+                "This API has no effect and no alternative is available. You would see this message"
+                    + " until ${DeployGatePlugin.ENV_NAME_APP_VISIBILITY} environment variable is"
+                    + " removed.");
         _internalSetVisibility(visibility);
     }
 
     @Deprecated
     public String getVisibility() {
-        DeprecationLogger.deprecation("NamedDeployment.getVisibility()", "2.5", "3.0", "This API has no effect and no alternative is available.");
+        DeprecationLogger.deprecation(
+                "NamedDeployment.getVisibility()",
+                "2.5",
+                "3.0",
+                "This API has no effect and no alternative is available.");
         return _internalGetVisibility();
     }
 
     @Deprecated
-    @Nullable
-    public String getDistributionKey() {
-        DeprecationLogger.deprecation("NamedDeployment.getDistributionKey()", "2.0", "3.0", "Use distribution closure directly.");
+    @Nullable public String getDistributionKey() {
+        DeprecationLogger.deprecation(
+                "NamedDeployment.getDistributionKey()",
+                "2.0",
+                "3.0",
+                "Use distribution closure directly.");
         return hasDistribution() ? getDistribution().getKey() : null;
     }
 
     @Deprecated
     public void setDistributionKey(@Nullable final String distributionKey) {
-        DeprecationLogger.deprecation("NamedDeployment.setDistributionKey(String)", "2.0", "3.0", "Use distribution closure instead.");
-        distribution(new Action<Distribution>() {
-            @Override
-            public void execute(Distribution distribution) {
-                distribution.setKey(distributionKey);
-            }
-        });
+        DeprecationLogger.deprecation(
+                "NamedDeployment.setDistributionKey(String)",
+                "2.0",
+                "3.0",
+                "Use distribution closure instead.");
+        distribution(
+                new Action<Distribution>() {
+                    @Override
+                    public void execute(Distribution distribution) {
+                        distribution.setKey(distributionKey);
+                    }
+                });
     }
 
     @Deprecated
-    @Nullable
-    public String getReleaseNote() {
-        DeprecationLogger.deprecation("NamedDeployment.getReleaseNote()", "2.0", "3.0", "Use distribution closure directly.");
+    @Nullable public String getReleaseNote() {
+        DeprecationLogger.deprecation(
+                "NamedDeployment.getReleaseNote()",
+                "2.0",
+                "3.0",
+                "Use distribution closure directly.");
         return hasDistribution() ? getDistribution().getReleaseNote() : null;
     }
 
     @Deprecated
     public void setReleaseNote(@Nullable final String releaseNote) {
-        DeprecationLogger.deprecation("NamedDeployment.setReleaseNote(String)", "2.0", "3.0", "Use distribution closure instead.");
-        distribution(new Action<Distribution>() {
-            @Override
-            public void execute(Distribution distribution) {
-                distribution.setReleaseNote(releaseNote);
-            }
-        });
+        DeprecationLogger.deprecation(
+                "NamedDeployment.setReleaseNote(String)",
+                "2.0",
+                "3.0",
+                "Use distribution closure instead.");
+        distribution(
+                new Action<Distribution>() {
+                    @Override
+                    public void execute(Distribution distribution) {
+                        distribution.setReleaseNote(releaseNote);
+                    }
+                });
     }
 
     @Deprecated
     public boolean getNoAssemble() {
-        DeprecationLogger.deprecation("NamedDeployment.getNoAssemble()", "2.0", "3.0", "Use isSkipAssemble() instead.");
+        DeprecationLogger.deprecation(
+                "NamedDeployment.getNoAssemble()", "2.0", "3.0", "Use isSkipAssemble() instead.");
         return isSkipAssemble();
     }
 
     @Deprecated
     public void setNoAssemble(boolean noAssemble) {
-        DeprecationLogger.deprecation("NamedDeployment.setNoAssemble(boolean)", "2.0", "3.0", "Use setSkipAssemble() instead.");
+        DeprecationLogger.deprecation(
+                "NamedDeployment.setNoAssemble(boolean)",
+                "2.0",
+                "3.0",
+                "Use setSkipAssemble() instead.");
         setSkipAssemble(noAssemble);
     }
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/syntax/DeploymentSyntax.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/syntax/DeploymentSyntax.groovy
@@ -2,9 +2,8 @@ package com.deploygate.gradle.plugins.dsl.syntax
 
 import com.deploygate.gradle.plugins.dsl.Distribution
 import org.gradle.api.Action
-
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 
 interface DeploymentSyntax {
     /**
@@ -38,12 +37,12 @@ interface DeploymentSyntax {
      *
      * @param closure
      */
-    void distribution(@Nonnull Closure closure) // for Groovy
+    void distribution(@NotNull Closure closure) // for Groovy
 
     /**
      * Configure parameters of a distribution
      *
      * @param builder
      */
-    void distribution(@Nonnull Action<Distribution> builder) // for Kotlin DSL
+    void distribution(@NotNull Action<Distribution> builder) // for Kotlin DSL
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/syntax/DistributionSyntax.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/syntax/DistributionSyntax.groovy
@@ -1,6 +1,6 @@
 package com.deploygate.gradle.plugins.dsl.syntax
 
-import javax.annotation.Nullable
+import org.jetbrains.annotations.Nullable
 
 interface DistributionSyntax {
     /**

--- a/src/main/groovy/com/deploygate/gradle/plugins/dsl/syntax/ExtensionSyntax.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/dsl/syntax/ExtensionSyntax.groovy
@@ -2,8 +2,7 @@ package com.deploygate.gradle.plugins.dsl.syntax
 
 import com.deploygate.gradle.plugins.dsl.NamedDeployment
 import org.gradle.api.NamedDomainObjectContainer
-
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 interface ExtensionSyntax {
     /**
@@ -12,7 +11,7 @@ interface ExtensionSyntax {
      * @param apiToken
      * @see com.deploygate.gradle.plugins.DeployGatePlugin#ENV_NAME_API_TOKEN
      */
-    void setApiToken(@Nonnull String apiToken)
+    void setApiToken(@NotNull String apiToken)
 
     /**
      * Set the application owner name.
@@ -20,7 +19,7 @@ interface ExtensionSyntax {
      * @param appOwnerName
      * @see com.deploygate.gradle.plugins.DeployGatePlugin#ENV_NAME_APP_OWNER_NAME
      */
-    void setAppOwnerName(@Nonnull String appOwnerName)
+    void setAppOwnerName(@NotNull String appOwnerName)
 
     /**
      * Define deployments for each product flavors.
@@ -32,6 +31,6 @@ interface ExtensionSyntax {
     /**
      * Define deployments for each product flavors.
      */
-    @Nonnull
+    @NotNull
     NamedDomainObjectContainer<NamedDeployment> getDeployments() // for Kotlin DSL
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/DeprecationLogger.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/DeprecationLogger.groovy
@@ -3,9 +3,8 @@ package com.deploygate.gradle.plugins.internal
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 
 final class DeprecationLogger {
     private final static LOCK = new Object();
@@ -31,7 +30,7 @@ final class DeprecationLogger {
         getLogger().clear()
     }
 
-    static void deprecation(@Nonnull String signature, @Nonnull String sinceVersion, @Nullable String versionToRemove, @Nonnull String message, Object... args) {
+    static void deprecation(@NotNull String signature, @NotNull String sinceVersion, @Nullable String versionToRemove, @NotNull String message, Object... args) {
         DeprecationLogger deprecationLogger = getLogger();
 
         if (!deprecationLogger.addSignature(signature)) {

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/VersionString.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/VersionString.groovy
@@ -1,21 +1,20 @@
 package com.deploygate.gradle.plugins.internal
 
+import java.util.regex.Pattern
 import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import javax.annotation.Nullable
-import java.util.regex.Pattern
 
 class VersionString implements Comparable<VersionString> {
     private static final Logger LOGGER = LoggerFactory.getLogger(this.getClass())
     private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)(?:\\.(\\d+))?\$")
     private static final Pattern PRERELEASE_TAG_PATTERN = Pattern.compile("^([a-zA-Z]+).*\$")
     private static final Map<String, Integer> PRERELEASE_DELTAS = [
-            "alpha": 1,
-            "beta": 2,
-            "rc": 3,
-            "": 100
+        "alpha": 1,
+        "beta": 2,
+        "rc": 3,
+        "": 100
     ]
 
     @Nullable
@@ -95,14 +94,12 @@ class VersionString implements Comparable<VersionString> {
     @Override
     int compareTo(@NotNull VersionString versionString) {
         return [
-                major <=> versionString.major,
-                minor <=> versionString.minor,
-                patch <=> versionString.patch,
-                PRERELEASE_DELTAS[prerelease ?: ""] <=> PRERELEASE_DELTAS[versionString.prerelease ?: ""],
-                metaBuild <=> versionString.metaBuild
-        ].find {
-            it != 0
-        } ?: 0
+            major <=> versionString.major,
+            minor <=> versionString.minor,
+            patch <=> versionString.patch,
+            PRERELEASE_DELTAS[prerelease ?: ""] <=> PRERELEASE_DELTAS[versionString.prerelease ?: ""],
+            metaBuild <=> versionString.metaBuild
+        ].find { it != 0 } ?: 0
     }
 
     @Override

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePlugin.groovy
@@ -7,12 +7,10 @@ import org.gradle.api.Project
 import org.jetbrains.annotations.NotNull
 import org.slf4j.Logger
 
-import javax.annotation.Nonnull
-
 class AndroidGradlePlugin {
     private static VersionString AGP_VERSION
 
-    static void ifPresent(@Nonnull Project project, @NotNull Action<?> onFound) {
+    static void ifPresent(@NotNull Project project, @NotNull Action<?> onFound) {
         try {
             def agpPlugin = project.plugins.findPlugin("com.android.application")
 
@@ -41,13 +39,13 @@ class AndroidGradlePlugin {
         return AGP_VERSION
     }
 
-    @Nonnull
-    static String androidAssembleTaskName(@Nonnull String variantName) {
+    @NotNull
+    static String androidAssembleTaskName(@NotNull String variantName) {
         return "assemble${variantName.capitalize()}"
     }
 
-    @Nonnull
-    static String androidBundleTaskName(@Nonnull String variantName) {
+    @NotNull
+    static String androidBundleTaskName(@NotNull String variantName) {
         return "bundle${variantName.capitalize()}"
     }
 
@@ -66,7 +64,7 @@ class AndroidGradlePlugin {
         return Integer.MAX_VALUE + ".0.0"
     }
 
-    private static void checkModelLevel(@Nonnull ClassLoader classLoader, @Nonnull Logger logger) {
+    private static void checkModelLevel(@NotNull ClassLoader classLoader, @NotNull Logger logger) {
         try {
             def modelLevel = classLoader.loadClass("com.android.builder.model.AndroidProject").getField("MODEL_LEVEL_LATEST").get(null).toString().toInteger()
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/IApplicationVariant.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/IApplicationVariant.groovy
@@ -2,17 +2,16 @@ package com.deploygate.gradle.plugins.internal.agp
 
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
-
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 interface IApplicationVariant {
 
-    @Nonnull
+    @NotNull
     String getName()
 
     /**
      * @return TaskProvider of com.android.build.gradle.tasks.PackageApplication
      */
-    @Nonnull
+    @NotNull
     TaskProvider<? extends Task> packageApplicationTaskProvider()
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/IApplicationVariantImpl.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/agp/IApplicationVariantImpl.groovy
@@ -2,26 +2,25 @@ package com.deploygate.gradle.plugins.internal.agp
 
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
-
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 class IApplicationVariantImpl implements IApplicationVariant {
-    @Nonnull
-//    private com.android.build.gradle.api.ApplicationVariant applicationVariant
+    @NotNull
+    //    private com.android.build.gradle.api.ApplicationVariant applicationVariant
     private def applicationVariant
 
-    IApplicationVariantImpl(@Nonnull /* ApplicationVariant */ applicationVariant) {
+    IApplicationVariantImpl(@NotNull /* ApplicationVariant */ applicationVariant) {
         this.applicationVariant = applicationVariant
     }
 
     @Override
-    @Nonnull
+    @NotNull
     String getName() {
         return applicationVariant.name
     }
 
     @Override
-    @Nonnull
+    @NotNull
     TaskProvider<? extends Task> packageApplicationTaskProvider() {
         return applicationVariant.packageApplicationProvider
     }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/annotation/DeployGateInternal.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/annotation/DeployGateInternal.java
@@ -7,5 +7,4 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.SOURCE)
-public @interface DeployGateInternal {
-}
+public @interface DeployGateInternal {}

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/gradle/GradleCompat.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/gradle/GradleCompat.groovy
@@ -3,8 +3,7 @@ package com.deploygate.gradle.plugins.internal.gradle
 import com.deploygate.gradle.plugins.internal.VersionString
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
-
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 class GradleCompat {
     private static VersionString GRADLE_VERSION
@@ -12,11 +11,11 @@ class GradleCompat {
     private GradleCompat() {
     }
 
-    static void init(@Nonnull Project project) {
+    static void init(@NotNull Project project) {
         GRADLE_VERSION = VersionString.tryParse(project.gradle.gradleVersion)
     }
 
-    @Nonnull
+    @NotNull
     static VersionString getVersion() {
         if (!GRADLE_VERSION) {
             throw new IllegalStateException("must be initialized")

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/gradle/ProviderFactoryUtils.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/gradle/ProviderFactoryUtils.java
@@ -4,14 +4,13 @@ import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.NotNull;
 
 public final class ProviderFactoryUtils {
-    private ProviderFactoryUtils() {
-    }
+    private ProviderFactoryUtils() {}
 
     /**
      * The new provider will return the first-seen value in providers.
      *
      * @param providers
-     * @param <T>       Value type
+     * @param <T> Value type
      * @return the first-seen value
      */
     public static <T> Provider<T> pickFirst(@NotNull Provider<T>... providers) {

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ApiClient.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ApiClient.java
@@ -7,11 +7,9 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.jetbrains.annotations.NotNull;
 
 public class ApiClient {
-    @NotNull
-    private final HttpClient httpClient;
+    @NotNull private final HttpClient httpClient;
 
-    @NotNull
-    private final Credentials credentials;
+    @NotNull private final Credentials credentials;
 
     /**
      * @param httpClient should be immutable
@@ -25,15 +23,21 @@ public class ApiClient {
     /**
      * Upload the application file to the app owner space
      *
-     * @param request      a request to the server that must contain a file
+     * @param request a request to the server that must contain a file
      * @return a successful response that contains a typed json.
      * @throws HttpResponseException is thrown if a request is an error inclduing 4xx and 5xx
-     * @throws NetworkFailure        is thrown if a network trouble happens
+     * @throws NetworkFailure is thrown if a network trouble happens
      */
     @SuppressWarnings("RedundantThrows")
-    @NotNull
-    public HttpClient.Response<UploadAppResponse> uploadApp(@NotNull UploadAppRequest request) throws HttpResponseException, NetworkFailure {
-        HttpUriRequestBase httpPost = httpClient.buildRequest(HttpPost.METHOD_NAME, "api", "users", credentials.getAppOwnerName().get(), "apps");
+    @NotNull public HttpClient.Response<UploadAppResponse> uploadApp(@NotNull UploadAppRequest request)
+            throws HttpResponseException, NetworkFailure {
+        HttpUriRequestBase httpPost =
+                httpClient.buildRequest(
+                        HttpPost.METHOD_NAME,
+                        "api",
+                        "users",
+                        credentials.getAppOwnerName().get(),
+                        "apps");
         httpPost.setEntity(request.toEntity());
 
         configureAuthorizationHeader(httpPost);

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ErrorResponse.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ErrorResponse.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class ErrorResponse {
 
-    @NotNull
-    @SerializedName("message")
+    @NotNull @SerializedName("message")
     public final String message = "";
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/GetCredentialsResponse.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/GetCredentialsResponse.java
@@ -4,11 +4,9 @@ import com.google.gson.annotations.SerializedName;
 import org.jetbrains.annotations.NotNull;
 
 public class GetCredentialsResponse {
-    @NotNull
-    @SerializedName("name")
+    @NotNull @SerializedName("name")
     public final String name = "";
 
-    @NotNull
-    @SerializedName("token")
+    @NotNull @SerializedName("token")
     public final String token = "";
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ILifecycleNotificationClient.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/ILifecycleNotificationClient.java
@@ -9,10 +9,10 @@ public interface ILifecycleNotificationClient {
      * Get the credentials from the server
      *
      * @throws HttpResponseException is thrown if a request is an error inclduing 4xx and 5xx
-     * @throws NetworkFailure        is thrown if a network trouble happens
+     * @throws NetworkFailure is thrown if a network trouble happens
      */
-    @Nullable
-    HttpClient.Response<GetCredentialsResponse> getCredentials() throws HttpResponseException, NetworkFailure;
+    @Nullable HttpClient.Response<GetCredentialsResponse> getCredentials()
+            throws HttpResponseException, NetworkFailure;
 
     boolean notifyOnCredentialSaved();
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/LifecycleNotificationClient.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/LifecycleNotificationClient.java
@@ -1,32 +1,35 @@
 package com.deploygate.gradle.plugins.internal.http;
 
+import java.util.Collections;
 import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-
 public class LifecycleNotificationClient implements ILifecycleNotificationClient {
-    @NotNull
-    private final HttpClient httpClient;
-    @NotNull
-    private final String notifyKey;
+    @NotNull private final HttpClient httpClient;
+    @NotNull private final String notifyKey;
 
     /**
      * @param httpClient a real http client
-     * @param notifyKey  a notification key. In general, this is generated in the authentication flow.
+     * @param notifyKey a notification key. In general, this is generated in the authentication
+     *     flow.
      */
     LifecycleNotificationClient(@NotNull HttpClient httpClient, @NotNull String notifyKey) {
         this.httpClient = httpClient;
         this.notifyKey = notifyKey;
     }
 
-    @NotNull
-    @Override
-    public HttpClient.Response<GetCredentialsResponse> getCredentials() throws HttpResponseException, NetworkFailure {
-        HttpUriRequestBase requestBase = httpClient.buildRequest(HttpGet.METHOD_NAME, Collections.singletonMap("key", notifyKey), "cli", "credential");
+    @NotNull @Override
+    public HttpClient.Response<GetCredentialsResponse> getCredentials()
+            throws HttpResponseException, NetworkFailure {
+        HttpUriRequestBase requestBase =
+                httpClient.buildRequest(
+                        HttpGet.METHOD_NAME,
+                        Collections.singletonMap("key", notifyKey),
+                        "cli",
+                        "credential");
 
         return httpClient.execute(requestBase, GetCredentialsResponse.class);
     }
@@ -64,11 +67,12 @@ public class LifecycleNotificationClient implements ILifecycleNotificationClient
      * @param request a request to the server that must contain an action name
      * @return true anyway
      * @throws HttpResponseException is thrown if a request is an error inclduing 4xx and 5xx
-     * @throws NetworkFailure        is thrown if a network trouble happens
+     * @throws NetworkFailure is thrown if a network trouble happens
      */
     private boolean notify(@NotNull NotifyActionRequest request) {
         try {
-            HttpUriRequestBase httpPost = httpClient.buildRequest(HttpPost.METHOD_NAME, "cli", "notify");
+            HttpUriRequestBase httpPost =
+                    httpClient.buildRequest(HttpPost.METHOD_NAME, "cli", "notify");
             httpPost.setEntity(request.toEntity(notifyKey));
 
             httpClient.execute(httpPost, Object.class);

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/NoOpLifecycleNotificationClient.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/NoOpLifecycleNotificationClient.java
@@ -5,8 +5,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class NoOpLifecycleNotificationClient implements ILifecycleNotificationClient {
     @Override
-    @Nullable
-    public HttpClient.Response<GetCredentialsResponse> getCredentials() {
+    @Nullable public HttpClient.Response<GetCredentialsResponse> getCredentials() {
         return null;
     }
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/NotifyActionRequest.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/NotifyActionRequest.java
@@ -1,5 +1,7 @@
 package com.deploygate.gradle.plugins.internal.http;
 
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.NameValuePair;
@@ -8,18 +10,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-
 public class NotifyActionRequest {
-    @NotNull
-    private final String action;
+    @NotNull private final String action;
 
-    @NotNull
-    private final Map<String, Object> data = new HashMap<>();
+    @NotNull private final Map<String, Object> data = new HashMap<>();
 
     public NotifyActionRequest(@NotNull String action) {
-        this.action = Objects.requireNonNull(action);
+        this.action = Objects.requireNotNull(action);
     }
 
     public void setParameter(@NotNull String name, @Nullable Object value) {

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/NotifyActionRequest.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/NotifyActionRequest.java
@@ -16,7 +16,7 @@ public class NotifyActionRequest {
     @NotNull private final Map<String, Object> data = new HashMap<>();
 
     public NotifyActionRequest(@NotNull String action) {
-        this.action = Objects.requireNotNull(action);
+        this.action = Objects.requireNonNull(action);
     }
 
     public void setParameter(@NotNull String name, @Nullable Object value) {

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/UploadAppRequest.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/UploadAppRequest.java
@@ -1,5 +1,9 @@
 package com.deploygate.gradle.plugins.internal.http;
 
+import static org.apache.hc.client5.http.entity.mime.HttpMultipartMode.EXTENDED;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.entity.mime.StringBody;
 import org.apache.hc.core5.http.ContentType;
@@ -7,29 +11,17 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-
-import static org.apache.hc.client5.http.entity.mime.HttpMultipartMode.EXTENDED;
-
 public class UploadAppRequest {
-    private static final ContentType UTF8_PLAIN_TEXT = ContentType.create(
-            "text/plain",
-            StandardCharsets.UTF_8
-    );
+    private static final ContentType UTF8_PLAIN_TEXT =
+            ContentType.create("text/plain", StandardCharsets.UTF_8);
 
-    @NotNull
-    private final File appFile;
+    @NotNull private final File appFile;
 
-    @Nullable
-    private String message;
-    @Nullable
-    private String distributionKey;
-    @Nullable
-    private String releaseNote;
+    @Nullable private String message;
+    @Nullable private String distributionKey;
+    @Nullable private String releaseNote;
 
-    @Nullable
-    private MultipartEntityBuilder builder;
+    @Nullable private MultipartEntityBuilder builder;
 
     public UploadAppRequest(@NotNull File appFile) {
         this(appFile, null);
@@ -52,8 +44,7 @@ public class UploadAppRequest {
         this.releaseNote = releaseNote;
     }
 
-    @NotNull
-    HttpEntity toEntity() {
+    @NotNull HttpEntity toEntity() {
         MultipartEntityBuilder builder;
 
         if (this.builder != null) {

--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/UploadAppResponse.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/UploadAppResponse.java
@@ -5,13 +5,11 @@ import org.jetbrains.annotations.NotNull;
 
 public class UploadAppResponse {
     @SuppressWarnings("ConstantConditions")
-    @NotNull
-    @SerializedName("results")
+    @NotNull @SerializedName("results")
     public final ApplicationFragment application = null;
 
     static class ApplicationFragment {
-        @NotNull
-        @SerializedName("path")
+        @NotNull @SerializedName("path")
         public final String path = "";
 
         @SerializedName("revision")

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/Constants.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/Constants.java
@@ -1,7 +1,7 @@
 package com.deploygate.gradle.plugins.tasks;
 
-import javax.annotation.Nonnull;
 import java.util.Locale;
+import org.jetbrains.annotations.NotNull;
 
 public class Constants {
     public static final String TASK_GROUP_NAME = "DeployGate";
@@ -12,18 +12,15 @@ public class Constants {
     public static String SUFFIX_APK_TASK_NAME = "uploadDeployGate";
     public static String SUFFIX_AAB_TASK_NAME = "uploadDeployGateAab";
 
-    @Nonnull
-    public static String uploadApkTaskName(@Nonnull String variantName) {
+    @NotNull public static String uploadApkTaskName(@NotNull String variantName) {
         return SUFFIX_APK_TASK_NAME + capitalize(variantName);
     }
 
-    @Nonnull
-    public static String uploadAabTaskName(@Nonnull String variantName) {
+    @NotNull public static String uploadAabTaskName(@NotNull String variantName) {
         return SUFFIX_AAB_TASK_NAME + capitalize(variantName);
     }
 
-    @Nonnull
-    private static String capitalize(@Nonnull String value) {
+    @NotNull private static String capitalize(@NotNull String value) {
         return value.substring(0, 1).toUpperCase(Locale.US) + value.substring(1);
     }
 }

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.groovy
@@ -1,13 +1,17 @@
 package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.dsl.DeployGateExtension
-import com.deploygate.gradle.plugins.internal.http.HttpClient
 import com.deploygate.gradle.plugins.internal.http.GetCredentialsResponse
+import com.deploygate.gradle.plugins.internal.http.HttpClient
 import com.deploygate.gradle.plugins.tasks.inputs.Credentials
 import com.deploygate.gradle.plugins.utils.BrowserUtils
 import com.deploygate.gradle.plugins.utils.UrlUtils
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
@@ -18,11 +22,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.VisibleForTesting
-
-import javax.inject.Inject
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 abstract class LoginTask extends DefaultTask {
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/LogoutTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/LogoutTask.groovy
@@ -1,11 +1,10 @@
 package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-
-import javax.inject.Inject
 
 abstract class LogoutTask extends DefaultTask {
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadAabTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadAabTask.groovy
@@ -2,6 +2,7 @@ package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.artifacts.AabInfo
 import com.deploygate.gradle.plugins.tasks.inputs.DeploymentConfiguration
+import javax.inject.Inject
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -10,8 +11,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.VisibleForTesting
-
-import javax.inject.Inject
 
 abstract class UploadAabTask extends UploadArtifactTask {
     @NotNull
@@ -25,7 +24,7 @@ abstract class UploadAabTask extends UploadArtifactTask {
                 message: deployment.message.getOrNull(),
                 distributionKey: deployment.distributionKey.getOrNull(),
                 releaseNote: deployment.distributionReleaseNote.getOrNull()
-        )
+                )
     }
 
     @Internal

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadApkTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadApkTask.groovy
@@ -2,6 +2,7 @@ package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.artifacts.ApkInfo
 import com.deploygate.gradle.plugins.tasks.inputs.DeploymentConfiguration
+import javax.inject.Inject
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -10,8 +11,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.VisibleForTesting
-
-import javax.inject.Inject
 
 abstract class UploadApkTask extends UploadArtifactTask {
     @NotNull
@@ -25,7 +24,7 @@ abstract class UploadApkTask extends UploadArtifactTask {
                 message: deployment.message.getOrNull(),
                 distributionKey: deployment.distributionKey.getOrNull(),
                 releaseNote: deployment.distributionReleaseNote.getOrNull()
-        )
+                )
     }
 
     @Internal

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
@@ -81,7 +81,11 @@ abstract class UploadArtifactTask extends DefaultTask {
         deployment = objectFactory.newInstance(DeploymentConfiguration)
         httpClient = objectFactory.property(HttpClient)
 
-        response = projectLayout.buildDirectory.file(["deploygate", name, "response.json"].join(File.separator))
+        response = projectLayout.buildDirectory.file([
+            "deploygate",
+            name,
+            "response.json"
+        ].join(File.separator))
     }
 
     @NotNull

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/inputs/Credentials.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/inputs/Credentials.java
@@ -1,13 +1,12 @@
 package com.deploygate.gradle.plugins.tasks.inputs;
 
+import java.util.Locale;
 import org.gradle.api.GradleException;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
-
-import java.util.Locale;
 
 public abstract class Credentials {
     @Input
@@ -29,14 +28,18 @@ public abstract class Credentials {
         presence(getApiToken(), "api token").finalizeValue();
     }
 
-    @NotNull
-    @VisibleForTesting
-    static Property<String> presence(@NotNull Property<String> property, @NotNull String displayName) {
+    @NotNull @VisibleForTesting
+    static Property<String> presence(
+            @NotNull Property<String> property, @NotNull String displayName) {
         // To keep the backward compatibility, we have to trim values *safely*.
         final String value = (property.getOrNull() != null ? property.get() : "").trim();
 
         if (value.isEmpty()) {
-            throw new GradleException(String.format(Locale.US, "%s is missing. Please configure the value properly.", displayName));
+            throw new GradleException(
+                    String.format(
+                            Locale.US,
+                            "%s is missing. Please configure the value properly.",
+                            displayName));
         } else {
             property.set(value);
         }

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/inputs/DeploymentConfiguration.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/inputs/DeploymentConfiguration.java
@@ -1,10 +1,12 @@
 package com.deploygate.gradle.plugins.tasks.inputs;
 
+import static com.deploygate.gradle.plugins.internal.gradle.GradleCompat.forUseAtConfigurationTime;
+
 import com.deploygate.gradle.plugins.DeployGatePlugin;
 import com.deploygate.gradle.plugins.dsl.Distribution;
 import com.deploygate.gradle.plugins.dsl.NamedDeployment;
-import com.deploygate.gradle.plugins.internal.gradle.GradleCompat;
 import com.deploygate.gradle.plugins.internal.gradle.ProviderFactoryUtils;
+import javax.inject.Inject;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
@@ -13,53 +15,64 @@ import org.gradle.api.tasks.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.inject.Inject;
-
-import static com.deploygate.gradle.plugins.internal.gradle.GradleCompat.forUseAtConfigurationTime;
-
 public abstract class DeploymentConfiguration {
 
-    /**
-     * must be an absolute path
-     */
+    /** must be an absolute path */
     @Input
     @Optional
-    @NotNull
-    public abstract Property<String> getSourceFilePath();
+    @NotNull public abstract Property<String> getSourceFilePath();
 
     @Input
     @Optional
-    @NotNull
-    public abstract Property<String> getMessage();
+    @NotNull public abstract Property<String> getMessage();
 
     @Input
-    @NotNull
-    public abstract Property<Boolean> getSkipAssemble();
-
-    @Input
-    @Optional
-    @NotNull
-    public abstract Property<String> getDistributionKey();
+    @NotNull public abstract Property<Boolean> getSkipAssemble();
 
     @Input
     @Optional
-    @NotNull
-    public abstract Property<String> getDistributionReleaseNote();
+    @NotNull public abstract Property<String> getDistributionKey();
+
+    @Input
+    @Optional
+    @NotNull public abstract Property<String> getDistributionReleaseNote();
 
     @Inject
-    public DeploymentConfiguration(@NotNull ProviderFactory providerFactory, @NotNull ProjectLayout projectLayout) {
-        getSourceFilePath().set(
-                forUseAtConfigurationTime(providerFactory.environmentVariable(DeployGatePlugin.getENV_NAME_SOURCE_FILE()))
-                        .map(s -> projectLayout.getProjectDirectory().file(s).getAsFile().getAbsolutePath())
-        );
-        getMessage().set(forUseAtConfigurationTime(providerFactory.environmentVariable(DeployGatePlugin.getENV_NAME_MESSAGE())));
-        getDistributionKey().set(forUseAtConfigurationTime(providerFactory.environmentVariable(DeployGatePlugin.getENV_NAME_DISTRIBUTION_KEY())));
-        getDistributionReleaseNote().set(
-                ProviderFactoryUtils.pickFirst(
-                        forUseAtConfigurationTime(providerFactory.environmentVariable(DeployGatePlugin.getENV_NAME_DISTRIBUTION_RELEASE_NOTE())),
-                        forUseAtConfigurationTime(providerFactory.environmentVariable(DeployGatePlugin.getENV_NAME_DISTRIBUTION_RELEASE_NOTE_V1()))
-                )
-        );
+    public DeploymentConfiguration(
+            @NotNull ProviderFactory providerFactory, @NotNull ProjectLayout projectLayout) {
+        getSourceFilePath()
+                .set(
+                        forUseAtConfigurationTime(
+                                        providerFactory.environmentVariable(
+                                                DeployGatePlugin.getENV_NAME_SOURCE_FILE()))
+                                .map(
+                                        s ->
+                                                projectLayout
+                                                        .getProjectDirectory()
+                                                        .file(s)
+                                                        .getAsFile()
+                                                        .getAbsolutePath()));
+        getMessage()
+                .set(
+                        forUseAtConfigurationTime(
+                                providerFactory.environmentVariable(
+                                        DeployGatePlugin.getENV_NAME_MESSAGE())));
+        getDistributionKey()
+                .set(
+                        forUseAtConfigurationTime(
+                                providerFactory.environmentVariable(
+                                        DeployGatePlugin.getENV_NAME_DISTRIBUTION_KEY())));
+        getDistributionReleaseNote()
+                .set(
+                        ProviderFactoryUtils.pickFirst(
+                                forUseAtConfigurationTime(
+                                        providerFactory.environmentVariable(
+                                                DeployGatePlugin
+                                                        .getENV_NAME_DISTRIBUTION_RELEASE_NOTE())),
+                                forUseAtConfigurationTime(
+                                        providerFactory.environmentVariable(
+                                                DeployGatePlugin
+                                                        .getENV_NAME_DISTRIBUTION_RELEASE_NOTE_V1()))));
         getSkipAssemble().set(false);
     }
 

--- a/src/main/groovy/com/deploygate/gradle/plugins/utils/BrowserUtils.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/utils/BrowserUtils.groovy
@@ -1,15 +1,15 @@
 package com.deploygate.gradle.plugins.utils
 
-import javax.annotation.Nonnull
+import org.jetbrains.annotations.NotNull
 
 class BrowserUtils {
 
-    @Nonnull
+    @NotNull
     private static String getOS_NAME() {
         return (System.getProperty("os.name") ?: "unknown").toLowerCase(Locale.US)
     }
 
-    static boolean openBrowser(@Nonnull String url) {
+    static boolean openBrowser(@NotNull String url) {
         if (hasBrowser()) {
             try {
                 if (isExecutableOnMacOS()) {
@@ -27,15 +27,15 @@ class BrowserUtils {
         false
     }
 
-    static boolean openBrowserForMac(@Nonnull String url) {
+    static boolean openBrowserForMac(@NotNull String url) {
         return ['open', url].execute().waitFor() == 0
     }
 
-    static boolean openBrowserForWindows(@Nonnull String url) {
+    static boolean openBrowserForWindows(@NotNull String url) {
         return ['cmd', '/c', 'start', url].execute().waitFor() == 0
     }
 
-    static boolean openBrowserForLinux(@Nonnull String url) {
+    static boolean openBrowserForLinux(@NotNull String url) {
         try {
             int result = ['xdg-open', url].execute().waitFor()
             if (result == 0) {

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceKtsTestSpec.groovy
@@ -14,7 +14,7 @@ class AcceptanceKtsTestSpec extends AcceptanceTestBaseSpec {
         given:
         testAndroidProject.useGradleKtsForBackwardCompatibilityResource()
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()

--- a/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestBaseSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/AcceptanceTestBaseSpec.groovy
@@ -2,21 +2,20 @@ package com.deploygate.gradle.plugins
 
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 abstract class AcceptanceTestBaseSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     TestAndroidProject testAndroidProject
 
-    @Nonnull
+    @NotNull
     TestDeployGatePlugin testDeployGatePlugin
 
     abstract void useProperResource()
@@ -31,7 +30,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "check tasks' existence #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -71,7 +70,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "check task children of uploadDeployGate #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -112,7 +111,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor1Flavor3Debug apk #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -136,7 +135,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor1Flavor3Debug aab #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -160,7 +159,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor2Flavor3Debug apk #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -184,7 +183,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor2Flavor3Debug aab #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -208,7 +207,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor1Flavor4Debug apk #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -232,7 +231,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor1Flavor4Debug aab #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -256,7 +255,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor2Flavor4Debug apk should fail unless assembling #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -279,7 +278,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor2Flavor4Debug aab should fail unless bundling #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -302,7 +301,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor2Flavor4Debug apk require assembling #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def assembleRunner = GradleRunner.create()
@@ -336,7 +335,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "flavor2Flavor4Debug aab require bundling #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def assembleRunner = GradleRunner.create()
@@ -370,7 +369,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "customApk apk #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()
@@ -394,7 +393,7 @@ abstract class AcceptanceTestBaseSpec extends Specification {
     def "customApk aab #agpVersion"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()

--- a/src/test/acceptance/com/deploygate/gradle/plugins/TestAndroidProject.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/TestAndroidProject.groovy
@@ -1,8 +1,7 @@
 package com.deploygate.gradle.plugins
 
+import org.jetbrains.annotations.NotNull
 import org.junit.rules.TemporaryFolder
-
-import javax.annotation.Nonnull
 
 class TestAndroidProject {
     private TemporaryFolder temporaryFolder
@@ -56,7 +55,7 @@ ndk.dir=${androidSdk}/ndk-bundle
         buildGradleKts << new File(dir, "build.gradle.kts").newInputStream()
     }
 
-    @Nonnull
+    @NotNull
     private File copyDir(String dirName) {
         def classLoader = getClass().getClassLoader()
         def dir = classLoader.getResource(dirName).file as File

--- a/src/test/acceptance/com/deploygate/gradle/plugins/VersionString.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/VersionString.groovy
@@ -1,10 +1,9 @@
 package com.deploygate.gradle.plugins
 
+import java.util.regex.Pattern
+import org.jetbrains.annotations.Nullable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import javax.annotation.Nullable
-import java.util.regex.Pattern
 
 class VersionString {
     private static final Logger LOGGER = LoggerFactory.getLogger(this.getClass())

--- a/src/test/acceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
+++ b/src/test/acceptance/com/deploygate/gradle/plugins/internal/agp/AndroidGradlePluginAcceptanceSpec.groovy
@@ -3,21 +3,20 @@ package com.deploygate.gradle.plugins.internal.agp
 import com.deploygate.gradle.plugins.TestAndroidProject
 import com.deploygate.gradle.plugins.TestDeployGatePlugin
 import org.gradle.testkit.runner.GradleRunner
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class AndroidGradlePluginAcceptanceSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     TestAndroidProject testAndroidProject
 
-    @Nonnull
+    @NotNull
     TestDeployGatePlugin testDeployGatePlugin
 
     def setup() {
@@ -40,7 +39,7 @@ class AndroidGradlePluginAcceptanceSpec extends Specification {
     def "version verification"() {
         given:
         testAndroidProject.gradleProperties([
-                "agpVersion": agpVersion
+            "agpVersion": agpVersion
         ])
 
         def runner = GradleRunner.create()

--- a/src/test/groovy/com/deploygate/gradle/plugins/internal/gradle/ProviderFactorySpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/internal/gradle/ProviderFactorySpec.groovy
@@ -2,18 +2,17 @@ package com.deploygate.gradle.plugins.internal.gradle
 
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class ProviderFactorySpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {

--- a/src/test/groovy/com/deploygate/gradle/plugins/internal/http/ApiClientSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/internal/http/ApiClientSpec.groovy
@@ -4,19 +4,18 @@ import com.deploygate.gradle.plugins.tasks.inputs.Credentials
 import org.apache.hc.client5.http.HttpResponseException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import javax.annotation.Nonnull
 
 class ApiClientSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {

--- a/src/test/groovy/com/deploygate/gradle/plugins/internal/http/HttpClientResponseSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/internal/http/HttpClientResponseSpec.groovy
@@ -2,18 +2,17 @@ package com.deploygate.gradle.plugins.internal.http
 
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class HttpClientResponseSpec  extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {

--- a/src/test/groovy/com/deploygate/gradle/plugins/internal/http/UploadAppRequestSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/internal/http/UploadAppRequestSpec.groovy
@@ -1,12 +1,11 @@
 package com.deploygate.gradle.plugins.internal.http
 
 
+import java.nio.charset.StandardCharsets
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder
 import org.apache.hc.client5.http.entity.mime.StringBody
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.nio.charset.StandardCharsets
 
 class UploadAppRequestSpec extends Specification {
     @Unroll

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
@@ -1,8 +1,9 @@
 package com.deploygate.gradle.plugins.tasks
 
-import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.dsl.DeployGateExtension
 import com.deploygate.gradle.plugins.dsl.NamedDeployment
+import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
+import javax.inject.Inject
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
@@ -12,9 +13,6 @@ import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
-import javax.inject.Inject
 
 class LoginTaskSpec extends Specification {
     static abstract class StubLoginTask extends LoginTask {
@@ -40,7 +38,7 @@ class LoginTaskSpec extends Specification {
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadAabTaskInputParamsSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadAabTaskInputParamsSpec.groovy
@@ -5,19 +5,18 @@ import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
 import com.deploygate.gradle.plugins.tasks.inputs.DeploymentConfiguration
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import javax.annotation.Nonnull
 
 class UploadAabTaskInputParamsSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {
@@ -72,5 +71,4 @@ class UploadAabTaskInputParamsSpec extends Specification {
         new File("build.gradle") | null
         new File("build.gradle") | new File("build2.gradle")
     }
-
 }

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadAabTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadAabTaskSpec.groovy
@@ -3,18 +3,17 @@ package com.deploygate.gradle.plugins.tasks
 
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class UploadAabTaskSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadApkTaskInputParamsSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadApkTaskInputParamsSpec.groovy
@@ -5,19 +5,18 @@ import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
 import com.deploygate.gradle.plugins.tasks.inputs.DeploymentConfiguration
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import javax.annotation.Nonnull
 
 class UploadApkTaskInputParamsSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {
@@ -74,5 +73,4 @@ class UploadApkTaskInputParamsSpec extends Specification {
         new File("build.gradle") | null
         new File("build.gradle") | new File("build2.gradle")
     }
-
 }

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadApkTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadApkTaskSpec.groovy
@@ -1,24 +1,23 @@
 package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.artifacts.DirectApkInfo
-import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.dsl.DeployGateExtension
 import com.deploygate.gradle.plugins.dsl.NamedDeployment
+import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class UploadApkTaskSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTaskSpec.groovy
@@ -1,9 +1,10 @@
 package com.deploygate.gradle.plugins.tasks
 
-import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.dsl.DeployGateExtension
 import com.deploygate.gradle.plugins.dsl.NamedDeployment
+import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
+import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
@@ -15,9 +16,6 @@ import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
-import javax.inject.Inject
 
 class UploadArtifactTaskSpec extends Specification {
     static class UploadArtifactTaskStub extends UploadArtifactTask {
@@ -34,7 +32,7 @@ class UploadArtifactTaskSpec extends Specification {
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {
@@ -51,7 +49,7 @@ class UploadArtifactTaskSpec extends Specification {
         def inputParams = new UploadArtifactTask.InputParams(
                 variantName: "dep1",
                 artifactFilePath: new File(project.buildDir, "not_found").absolutePath
-        )
+                )
 
         when: "apkFile must exist"
         def task = project.tasks.create("UploadArtifactTaskStub2", UploadArtifactTaskStub, inputParams)

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/inputs/CredentialsSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/inputs/CredentialsSpec.groovy
@@ -4,18 +4,17 @@ package com.deploygate.gradle.plugins.tasks.inputs
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class CredentialsSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {
@@ -82,6 +81,4 @@ class CredentialsSpec extends Specification {
         credentials.appOwnerName.get() == "app owner"
         credentials.apiToken.get() == "api token"
     }
-
 }
-

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/inputs/DeploymentConfigurationSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/inputs/DeploymentConfigurationSpec.groovy
@@ -5,18 +5,17 @@ import com.deploygate.gradle.plugins.dsl.NamedDeployment
 import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import javax.annotation.Nonnull
 
 class DeploymentConfigurationSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     private Project project
 
     def setup() {
@@ -82,5 +81,4 @@ class DeploymentConfigurationSpec extends Specification {
         base.distributionReleaseNote.getOrNull() == "other distributionReleaseNote"
         base.skipAssemble
     }
-
 }

--- a/src/test/groovy/com/deploygate/gradle/plugins/utils/BrowserUtilsSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/utils/BrowserUtilsSpec.groovy
@@ -14,21 +14,14 @@ class BrowserUtilsSpec extends Specification {
     @Unroll
     def "openBrowser. Unrolled #name"() {
         given:
-        [""].class.metaClass.execute = { ->
+        [""].class.metaClass.execute = {
+            ->
             [waitFor: { -> 0 }]
         }
-        BrowserUtils.metaClass.static.hasBrowser = { ->
-            hasBrowser
-        }
-        BrowserUtils.metaClass.static.isExecutableOnMacOS = { ->
-            onMacOS
-        }
-        BrowserUtils.metaClass.static.isExecutableOnWindows = { ->
-            onWindows
-        }
-        BrowserUtils.metaClass.static.isExecutableOnLinux = { ->
-            onLinux
-        }
+        BrowserUtils.metaClass.static.hasBrowser = { -> hasBrowser }
+        BrowserUtils.metaClass.static.isExecutableOnMacOS = { -> onMacOS }
+        BrowserUtils.metaClass.static.isExecutableOnWindows = { -> onWindows }
+        BrowserUtils.metaClass.static.isExecutableOnLinux = { -> onLinux }
 
         expect:
         BrowserUtils.openBrowser(url) == result
@@ -46,8 +39,8 @@ class BrowserUtilsSpec extends Specification {
     def "isCiEnvironment. Unrolled #name"() {
         given:
         envStub.setEnv([
-                "CI"         : isCI,
-                "JENKINS_URL": jenkinsUrl
+            "CI"         : isCI,
+            "JENKINS_URL": jenkinsUrl
         ])
 
         expect:
@@ -67,11 +60,9 @@ class BrowserUtilsSpec extends Specification {
     def "isExecutableXXX. Unrolled osName is #osName"() {
         given:
         envStub.setEnv([
-                "DISPLAY": display,
+            "DISPLAY": display,
         ])
-        BrowserUtils.metaClass.static.getOS_NAME = { ->
-            osName
-        }
+        BrowserUtils.metaClass.static.getOS_NAME = { -> osName }
 
         expect:
         BrowserUtils.isExecutableOnMacOS() == onMacOS
@@ -96,18 +87,10 @@ class BrowserUtilsSpec extends Specification {
     @Unroll
     def "hasBrowser. Unrolled #name"() {
         given:
-        BrowserUtils.metaClass.static.isCiEnvironment = { ->
-            isCI
-        }
-        BrowserUtils.metaClass.static.isExecutableOnMacOS = { ->
-            onMacOS
-        }
-        BrowserUtils.metaClass.static.isExecutableOnWindows = { ->
-            onWindows
-        }
-        BrowserUtils.metaClass.static.isExecutableOnLinux = { ->
-            onLinux
-        }
+        BrowserUtils.metaClass.static.isCiEnvironment = { -> isCI }
+        BrowserUtils.metaClass.static.isExecutableOnMacOS = { -> onMacOS }
+        BrowserUtils.metaClass.static.isExecutableOnWindows = { -> onWindows }
+        BrowserUtils.metaClass.static.isExecutableOnLinux = { -> onLinux }
 
         expect:
         BrowserUtils.hasBrowser() == result

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/TestAndroidProject.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/TestAndroidProject.groovy
@@ -1,8 +1,7 @@
 package com.deploygate.gradle.plugins
 
+import org.jetbrains.annotations.NotNull
 import org.junit.rules.TemporaryFolder
-
-import javax.annotation.Nonnull
 
 class TestAndroidProject {
     private TemporaryFolder temporaryFolder
@@ -64,7 +63,7 @@ ndk.dir=${androidSdk}/ndk-bundle
         buildGradleKts << new File(dir, "build.gradle.kts").newInputStream()
     }
 
-    @Nonnull
+    @NotNull
     private File copyDir(String dirName) {
         def classLoader = getClass().getClassLoader()
         def dir = classLoader.getResource(dirName).file as File

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/VersionString.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/VersionString.groovy
@@ -1,10 +1,9 @@
 package com.deploygate.gradle.plugins
 
+import java.util.regex.Pattern
+import org.jetbrains.annotations.Nullable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import javax.annotation.Nullable
-import java.util.regex.Pattern
 
 class VersionString {
     private static final Logger LOGGER = LoggerFactory.getLogger(this.getClass())

--- a/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
+++ b/src/test/unrollAcceptance/com/deploygate/gradle/plugins/internal/gradle/GradleCompatAcceptanceSpec.groovy
@@ -4,6 +4,7 @@ import com.deploygate.gradle.plugins.TestAndroidProject
 import com.deploygate.gradle.plugins.TestDeployGatePlugin
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.jetbrains.annotations.NotNull
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.IgnoreIf
@@ -11,17 +12,15 @@ import spock.lang.Requires
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import javax.annotation.Nonnull
-
 class GradleCompatAcceptanceSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @Nonnull
+    @NotNull
     TestAndroidProject testAndroidProject
 
-    @Nonnull
+    @NotNull
     TestDeployGatePlugin testDeployGatePlugin
 
     def setup() {
@@ -48,9 +47,7 @@ class GradleCompatAcceptanceSpec extends Specification {
         buildResult.task(":tasks").outcome == TaskOutcome.SUCCESS
 
         where:
-        gradleVersion << [
-                "7.0.2"
-        ]
+        gradleVersion << ["7.0.2"]
     }
 
     @Requires(value = { jvm.isJavaVersionCompatible(17) }, reason = "jdk 17 or higher cannot evaluate old Gradles that depend on jvm7")
@@ -70,8 +67,6 @@ class GradleCompatAcceptanceSpec extends Specification {
         buildResult.task(":tasks").outcome == TaskOutcome.SUCCESS
 
         where:
-        gradleVersion << [
-                "8.0"
-        ]
+        gradleVersion << ["8.0"]
     }
 }


### PR DESCRIPTION
Java, Groovy, Gradle and some misc files are formatted by spotless. The configuration follows the famous format styles though, we tuned some configuration for example 4 spaces as indent size.

To use spotless, we bumped up the min requirement of JRE in development to Java11.