### PR TITLE
Builds would fail if api token is found but app owner name is not found

### DIFF
--- a/src/main/groovy/com/deploygate/gradle/plugins/internal/http/HttpClient.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/internal/http/HttpClient.java
@@ -158,7 +158,8 @@ public abstract class HttpClient implements BuildService<HttpClient.Params>, Aut
                         file.toPath(),
                         rawResponse.getBytes(StandardCharsets.UTF_8),
                         StandardOpenOption.WRITE,
-                        StandardOpenOption.CREATE);
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING);
             } catch (IOException ignore) {
             }
         }

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.java
@@ -145,6 +145,13 @@ public abstract class LoginTask extends DefaultTask {
             return;
         }
 
+        if (!credentials.getAppOwnerName().isPresent() && credentials.getApiToken().isPresent()) {
+            getLogger().error("An api token is provided but no app owner name is found.");
+            getLogger().error("This behaviour has been obsoleted. See https://github.com/DeployGate/gradle-deploygate-plugin/issues/171.");
+
+            throw new GradleException("An app owner name is required to proceed");
+        }
+
         getLogger().info("Starting the authentication flow.");
 
         if (!setupCredential()) {

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.java
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/LoginTask.java
@@ -147,7 +147,10 @@ public abstract class LoginTask extends DefaultTask {
 
         if (!credentials.getAppOwnerName().isPresent() && credentials.getApiToken().isPresent()) {
             getLogger().error("An api token is provided but no app owner name is found.");
-            getLogger().error("This behaviour has been obsoleted. See https://github.com/DeployGate/gradle-deploygate-plugin/issues/171.");
+            getLogger()
+                    .error(
+                            "This behaviour has been obsoleted. See"
+                                + " https://github.com/DeployGate/gradle-deploygate-plugin/issues/171.");
 
             throw new GradleException("An app owner name is required to proceed");
         }

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
@@ -5,6 +5,7 @@ import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
 import org.gradle.api.GradleException
 
 import javax.inject.Inject
+import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
@@ -2,6 +2,8 @@ package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
+import org.gradle.api.GradleException
+
 import javax.inject.Inject
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -110,5 +112,23 @@ class LoginTaskSpec extends Specification {
         then: "do not use the credential store's values"
         loginTask4.credentials.getApiToken().get() == "ext.token"
         loginTask4.credentials.getAppOwnerName().get() == "ext.appOwnerName"
+    }
+
+    def "forbid specific input states"() {
+        setup:
+        def credentialsDirPathProvider = project.providers.provider { testProjectDir.root.absolutePath }
+        project.tasks.register("loginTask1", StubLoginTask) { task ->
+            task.credentialsDirPath.set(credentialsDirPathProvider)
+            task.explicitApiToken.set("ext.token")
+            task.stubApiToken = "stub.token"
+            task.stubAppOwnerName = "stub.appOwnerName"
+        }
+
+        when:
+        StubLoginTask loginTask1 = project.tasks.getByName("loginTask1") as StubLoginTask
+        loginTask1.execute()
+
+        then: "fail if only api token is provided"
+        thrown(GradleException)
     }
 }

--- a/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/tasks/LoginTaskSpec.groovy
@@ -2,8 +2,6 @@ package com.deploygate.gradle.plugins.tasks
 
 import com.deploygate.gradle.plugins.internal.credentials.CliCredentialStore
 import com.deploygate.gradle.plugins.internal.gradle.GradleCompat
-import org.gradle.api.GradleException
-
 import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer


### PR DESCRIPTION
Close #171

Don't allow a situation that an app owner name is not available but an api token is provided. 

This includes a bug fix related to a response file.

![ss 2023-03-17 at 10 20 22](https://user-images.githubusercontent.com/4340693/225789499-174d13ad-5d2d-4cd3-aff0-4ec42a6ccf9b.png)
