### PR TITLE
dependabot seems to be fired up too much.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,4 @@ updates:
       interval: "weekly"
     reviewers:
       - DeployGate/gradle-plugin-reviewer
+    open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
       interval: "weekly"
     reviewers:
       - DeployGate/gradle-plugin-reviewer
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gradle"
     directory: "/"


### PR DESCRIPTION
Reduce # of opened PRs by dependabot.

- Limit # of PRs for gradle
- Group updates for GitHub Actions