### PR TITLE
Prevent using same names for different artifacts in a workflow run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-reports
+          name: acceptance-test-reports
           path: build/reports/tests/testUnrollAcceptanceTest
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Fix https://github.com/DeployGate/gradle-deploygate-plugin/actions/runs/8228856588