### PR TITLE
Fix: use sonatype user token for uploading artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           echo >> gradle.properties
           cat<<EOF >> gradle.properties
           systemProp.org.gradle.internal.http.socketTimeout=120000
-          nexusUsername=${{ secrets.SHARED_NEXUS_USERNAME }}
-          nexusPassword=${{ secrets.SHARED_NEXUS_PASSWORD }}
+          nexusUsername=${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
+          nexusPassword=${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
           EOF
       - name: Publish artifacts
         run: ./release.sh


### PR DESCRIPTION
These changes as same as [this pull request at deploygate-android-sdk](https://github.com/DeployGate/deploygate-android-sdk/pull/91)

-----

According to [the notice from sonatype](https://central.sonatype.org/news/20240617_migration_of_accounts/#the-impact-on-ossrh-and-the-central-publisher-portal), we cannot use username and password when uploading artifacts to the repository.

So, we should use a user token in our GitHub Actions workflow.

Ref. https://central.sonatype.org/news/20240617_migration_of_accounts/#the-impact-on-ossrh-and-the-central-publisher-portal