### PR TITLE
Env stub class for testing is broken

### DIFF
--- a/src/test/groovy/com/deploygate/gradle/plugins/TestSystemEnv.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/TestSystemEnv.groovy
@@ -20,7 +20,9 @@ class TestSystemEnv extends ExternalResource {
 
     @Override
     protected void after() {
-        System.metaClass.static.getenv = null
+        System.metaClass.static.getenv = { String name ->
+            realEnv[name]
+        }
     }
 
     def setEnv(Map<String, Object> env) {

--- a/src/test/groovy/com/deploygate/gradle/plugins/TestSystemEnv.groovy
+++ b/src/test/groovy/com/deploygate/gradle/plugins/TestSystemEnv.groovy
@@ -5,12 +5,16 @@ import org.junit.rules.ExternalResource
 class TestSystemEnv extends ExternalResource {
     private Map<String, Object> envStub = new HashMap<String, Object>()
 
-    def realEnv = System.getenv()
+    private def realEnv = System.getenv()
 
     @Override
     protected void before() throws Throwable {
         System.metaClass.static.getenv = { String name ->
-            envStub[name] as String
+            if (envStub.containsKey(name)) {
+                envStub[name] as String
+            } else {
+                realEnv[name]
+            }
         }
     }
 


### PR DESCRIPTION
Environment variables were purged due to mock implementation so that HttpClient cannot look up required values.