### PR TITLE
fix: use correct value for access to Nexus Repository Manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           cat<<EOF >> gradle.properties
           systemProp.org.gradle.internal.http.socketTimeout=120000
           nexusUsername=${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
-          nexusPassword=${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
+          nexusPassword=${{ secrets.SHARED_NEXUS_TOKEN_PASSWORD }}
           EOF
       - name: Publish artifacts
         run: ./release.sh


### PR DESCRIPTION
I made the mistake of using an incorrect secret value when releasing an artifact.