### PR TITLE
fix: Move byte-buddy to testImplementation scope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     testImplementation 'org.objenesis:objenesis:3.4'
-    implementation 'net.bytebuddy:byte-buddy:1.15.11'
+    testImplementation 'net.bytebuddy:byte-buddy:1.15.11'
 
     if (requireGroovy3) {
         testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     testImplementation 'org.objenesis:objenesis:3.4'
-    testImplementation 'net.bytebuddy:byte-buddy:1.15.11'
+    testImplementation 'net.bytebuddy:byte-buddy:1.18.9'
 
     if (requireGroovy3) {
         testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'


### PR DESCRIPTION
Closes #281

## Summary

`net.bytebuddy:byte-buddy` was declared with `implementation` scope, but it is only needed by Spock for mocking concrete classes at test time (it is never referenced under `src/`). This incorrect scope put byte-buddy on the plugin runtime classpath, so Gradle TestKit injected and repackaged it during acceptance tests — and dependabot's bump to 1.18.9 broke that repackaging on older Gradle (≤ 8.2), failing all acceptance tests with `Failed to create Jar file byte-buddy-1.18.9.jar`.

See #281 for the full root-cause analysis and history.

## Changes

- Move `net.bytebuddy:byte-buddy` from `implementation` to `testImplementation`, matching the neighboring `objenesis` declaration.
- Apply the #279-equivalent deps update (bump byte-buddy `1.15.11` → `1.18.9`) to verify the scope fix resolves the breakage on older Gradle via CI.

## Verification

- Confirmed byte-buddy no longer appears in `createClasspathManifest` / `sourceSets.main.runtimeClasspath` (the TestKit-injected plugin classpath), so the jar-repackaging failure can no longer occur on any Gradle version.
- Confirmed byte-buddy is removed from `runtimeClasspath` but retained on `testRuntimeClasspath` (Spock concrete-class mocking preserved).
- The remaining acceptance-test verification (older Gradle versions) is delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)