### PR TITLE
chore(dependabot): add 3-day cooldown for supply-chain safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 3
     directory: "/"
     schedule:
       interval: "weekly"
@@ -12,6 +14,8 @@ updates:
           - "*"
 
   - package-ecosystem: "gradle"
+    cooldown:
+      default-days: 3
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## 概要
サプライチェーン攻撃のリスク低減のため、Dependabot に **3日間の cooldown** を設定します。新しく公開された依存バージョンへの更新 PR を 3 日間遅延させ、公開直後の悪意あるバージョンを取り込みにくくします。

## 変更内容
- 各 `updates` エントリに `cooldown.default-days: 3` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deploygate/gradle-deploygate-plugin/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->