### PR TITLE
ci: fix release.yml tag trigger to match multi-digit versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,12 @@ name: Release artifacts
 on:
   push:
     tags:
-      - \d.\d.\d
-      - \d.\d.\d-(alpha|rc)\d\d
+      # `\d` matches a single digit, so `\d.\d.\d` matched single-digit versions
+      # (2.9.0, ...) but not 2.10.0's two-digit "10". `[0-9]+` matches one or
+      # more digits per component (`+` = "one or more of the preceding character",
+      # per the docs' own `v[12].[0-9]+.[0-9]+` example that matches v1.10.1).
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   production-release:


### PR DESCRIPTION
## Summary

Pushing the `2.10.0` tag started no release.

`\d` matches a **single digit**, so the tag pattern `\d.\d.\d` matched
single-digit versions (2.9.0, 2.8.0, … — confirmed by their release workflow
runs/Slack notifications) but not `2.10.0`, whose middle component `10` has two
digits.

### Fix
```yaml
on:
  push:
    tags:
      - '[0-9]+.[0-9]+.[0-9]+'
      - '[0-9]+.[0-9]+.[0-9]+-*'   # pre-releases (e.g. 2.10.0-rc01)
```
`[0-9]+` matches one or more digits per component. Per the GitHub filter-pattern
docs, `+` means "one or more of the preceding character" and the official semver
example is `v[12].[0-9]+.[0-9]+` (which matches `v1.10.1`).

### Follow-up to publish 2.10.0
The existing `2.10.0` tag was pushed before this fix and points at a commit
without it; tag-push events evaluate the workflow from the tag's own commit, so
it won't retroactively trigger. After this merges, delete and re-create the
`2.10.0` tag on the updated master so the corrected trigger fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
