### PR TITLE
ci: run the release job on Java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
             exit 1
           fi
       - uses: ./.github/actions/setup-java
+        with:
+          java-version: 17
       - name: Set up gradle.properties for signing and nexus
         # Add timeout setting due to https://github.com/DeployGate/gradle-deploygate-plugin/runs/2523846388
         run: |


### PR DESCRIPTION
The `2.10.0` tag now triggers the release workflow (after #292), but the publish failed:

```
> Dependency requires at least JVM runtime version 17. This build uses a Java 11 JVM.
```

The publish build runs on the Gradle 8.14.3 wrapper (which, with AGP 8.x test deps and Spotless 8.6, requires JDK 17), but `release.yml` used the default Java 11. This passes `java-version: 17` to `setup-java`, matching the `unit-test` / `lint` / `acceptance-test` jobs.

After merge, re-cut the `2.10.0` tag once more so the corrected release job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)