### PR TITLE
build: dual-publish 2.10.0 to the Gradle Plugin Portal and Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
           systemProp.org.gradle.internal.http.socketTimeout=120000
           nexusUsername=${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
           nexusPassword=${{ secrets.SHARED_NEXUS_TOKEN_PASSWORD }}
+          gradle.publish.key=${{ secrets.GRADLE_PORTAL_PUBLISH_KEY }}
+          gradle.publish.secret=${{ secrets.GRADLE_PORTAL_PUBLISH_SECRET }}
           EOF
       - name: Publish artifacts
         run: ./release.sh
@@ -52,10 +54,14 @@ jobs:
           TEST_SERVER_URL: http://localhost:${{ job.services.app.ports[3000] }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+          # Central Portal user token, reused by the finalization POST in release.sh that
+          # transfers the OSSRH-staging upload to Maven Central.
+          CENTRAL_TOKEN_USERNAME: ${{ secrets.SHARED_NEXUS_TOKEN_USERNAME }}
+          CENTRAL_TOKEN_PASSWORD: ${{ secrets.SHARED_NEXUS_TOKEN_PASSWORD }}
       - name: Slack Notification
         # we use specific version(v2.2.1) for avoid nested dependency
         uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # v2.2.1
         env:
           SLACK_TITLE: 'Gradle Plugin Release'
-          SLACK_MESSAGE: "${{ github.ref }} has been published to Sonatype. ref: https://oss.sonatype.org/"
+          SLACK_MESSAGE: "${{ github.ref }} has been published to Maven Central and the Gradle Plugin Portal. refs: https://central.sonatype.com/ , https://plugins.gradle.org/plugin/com.deploygate"
           SLACK_WEBHOOK: ${{ secrets.SHARED_FOR_RELEASE_ARTIFACT_SLACK_INCOMING_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@ This is the DeployGate plugin for the Gradle. You can build and deploy your apps
 
 Snapshot? See [how to use snapshot](#snapshot)
 
-1 ) Add mavenCentral and the dependency of this plugin to your *build.gradle*.
+1 ) Apply this plugin to your app module.
+
+**Recommended: the plugins DSL** (resolves from the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.deploygate); no extra repository setup needed)
+
+```groovy
+plugins {
+    id "com.android.application" // It's better to apply the Android plugin first.
+    id "com.deploygate" version "the latest version"
+}
+```
+
+**Alternative: the legacy `buildscript` classpath** (resolves from Maven Central)
 
 ```groovy
 buildscript {
@@ -25,45 +36,14 @@ buildscript {
     classpath "com.deploygate:gradle:$deployGatePluginVersion"
   }
 }
-```
 
-If you are using the new plugin block DSL, then the following is required in your *settings.gradle*.
-
-```groovy
-pluginManagement {
-    repositories {
-        mavenCentral()
-    }
-    resolutionStrategy {
-        eachPlugin {
-            switch (requested.id.id) {
-                case "deploygate":
-                    useModule("com.deploygate:gradle:${required.version}")
-                    break
-            }
-        }
-    }
-}
-```
-
-2 ) Apply this plugin to your app module
-
-```groovy
-apply plugin: 'com.android.application' // It's better to apply Android Plugin for Gradle first.
-apply plugin: 'deploygate'
-```
-
-*The new plugin block DSL*
-
-```groovy
-plugins {
-    id "com.deploygate" version "the latest version"
-}
+apply plugin: 'com.android.application' // It's better to apply the Android plugin first.
+apply plugin: 'deploygate'              // the bare `deploygate` id keeps working for back-compat
 ```
 
 This plugin does not work with non-app modules and/or library modules correctly.
 
-3 ) Ready for deployments. Run tasks which you need. Please check the *Usage#Tasks* section for the detail of added tasks.
+2 ) Ready for deployments. Run tasks which you need. Please check the *Usage#Tasks* section for the detail of added tasks.
 
 ### If you are using `dg` command (for MacOSX)
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,13 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
         mavenCentral()
     }
-    dependencies { classpath "com.diffplug.spotless:spotless-plugin-gradle:8.6.0" }
+    dependencies {
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:8.6.0"
+        // Publishes the plugin to the Gradle Plugin Portal. It transitively applies
+        // java-gradle-plugin (and maven-publish), which generates the plugin marker
+        // and the `com.deploygate` descriptor used by the plugins {} DSL.
+        classpath "com.gradle.publish:plugin-publish-plugin:2.1.1"
+    }
 }
 
 class VersionString implements Comparable<VersionString> {
@@ -85,6 +91,11 @@ class VersionString implements Comparable<VersionString> {
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+// Registers the `com.deploygate` plugin id on the Gradle Plugin Portal. This also
+// applies java-gradle-plugin, so the published jar carries a generated
+// `com.deploygate.properties` descriptor alongside the hand-written legacy
+// `deploygate.properties`, keeping both `apply plugin: 'deploygate'` and the new id working.
+apply plugin: 'com.gradle.plugin-publish'
 // Spotless 8.x requires Gradle 8.1+. The acceptance matrix runs this build on Gradle 8.0
 // (AGP 8.0's minimum) as well, where Spotless must not be applied.
 if (VersionString.parse(gradle.gradleVersion) >= VersionString.parse("8.1")) {
@@ -297,11 +308,36 @@ allprojects {
     }
 }
 
+// Gradle Plugin Portal metadata. Only the namespaced `com.deploygate` id is registered
+// here; the legacy bare `deploygate` id keeps working via the hand-written descriptor
+// shipped to Maven Central (the Portal requires a reverse-DNS namespace).
+gradlePlugin {
+    website = 'https://github.com/DeployGate/gradle-deploygate-plugin'
+    vcsUrl = 'https://github.com/DeployGate/gradle-deploygate-plugin'
+    plugins {
+        deploygate {
+            id = 'com.deploygate'
+            implementationClass = 'com.deploygate.gradle.plugins.DeployGatePlugin'
+            displayName = 'Gradle DeployGate Plugin'
+            description = 'Build and deploy your apps to DeployGate by running a single Gradle task.'
+            tags.set([
+                'deploygate',
+                'android',
+                'deployment',
+                'distribution'
+            ])
+        }
+    }
+}
+
 afterEvaluate {
     publishing {
         repositories {
             maven {
-                url = isRelease() ? "https://oss.sonatype.org/service/local/staging/deploy/maven2/" : "https://oss.sonatype.org/content/repositories/snapshots/"
+                // The legacy Sonatype OSSRH was sunset on 2025-06-30. Publish through the
+                // Central Portal's OSSRH Staging API compatibility endpoint instead; a
+                // finalization POST in release.sh then transfers the deployment to Maven Central.
+                url = isRelease() ? "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/" : "https://central.sonatype.com/repository/maven-snapshots/"
 
                 credentials(PasswordCredentials) {
                     username = getRepositoryUsername()
@@ -312,9 +348,10 @@ afterEvaluate {
 
         publications {
             release(MavenPublication) {
+                // The plugin-publish plugin enables withSourcesJar()/withJavadocJar() on the java
+                // component, so components.java already carries the sources and javadoc jars; adding
+                // them again here would fail with "multiple artifacts with the identical ... classifier".
                 from components.java
-                artifact sourcesJar
-                artifact javadocJar
                 groupId = project.group
                 artifactId = archivesBaseName
                 version = project.version

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 # Publish in a single build to:
 #   * Maven Central  -> publishReleasePublicationToMavenRepository (com.deploygate:gradle)
@@ -18,6 +18,9 @@ set -eu
 # CENTRAL_TOKEN_USERNAME/PASSWORD are a Central Portal user token (the legacy OSSRH
 # credentials return 401). Skipped when unset so non-publishing invocations stay no-op.
 if [[ -n "${CENTRAL_TOKEN_USERNAME:-}" && -n "${CENTRAL_TOKEN_PASSWORD:-}" ]]; then
+    # NB: the Central Portal Publisher API uses the *Bearer* scheme with a base64(user:pass)
+    # token, not HTTP Basic. This is non-standard but documented:
+    # https://central.sonatype.org/publish/publish-portal-api/#authentication
     auth=$(printf '%s:%s' "${CENTRAL_TOKEN_USERNAME}" "${CENTRAL_TOKEN_PASSWORD}" | base64 | tr -d '\n')
     curl -fsS -X POST \
         -H "Authorization: Bearer ${auth}" \

--- a/release.sh
+++ b/release.sh
@@ -2,4 +2,24 @@
 
 set -eu
 
-./gradlew clean build publishReleasePublicationToMavenRepository --stacktrace
+# Publish in a single build to:
+#   * Maven Central  -> publishReleasePublicationToMavenRepository (com.deploygate:gradle)
+#   * Plugin Portal  -> publishPlugins                            (id com.deploygate)
+./gradlew clean build \
+    publishReleasePublicationToMavenRepository \
+    publishPlugins \
+    --stacktrace
+
+# The OSSRH Staging API compatibility endpoint only *stages* the Maven Central upload. This
+# POST hands the deployment over to the Central Portal and, with publishing_type=automatic,
+# releases it to Maven Central once validation passes. It must originate from the same host
+# that performed the upload, so it lives here rather than in a separate job.
+#
+# CENTRAL_TOKEN_USERNAME/PASSWORD are a Central Portal user token (the legacy OSSRH
+# credentials return 401). Skipped when unset so non-publishing invocations stay no-op.
+if [[ -n "${CENTRAL_TOKEN_USERNAME:-}" && -n "${CENTRAL_TOKEN_PASSWORD:-}" ]]; then
+    auth=$(printf '%s:%s' "${CENTRAL_TOKEN_USERNAME}" "${CENTRAL_TOKEN_PASSWORD}" | base64 | tr -d '\n')
+    curl -fsS -X POST \
+        -H "Authorization: Bearer ${auth}" \
+        "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.deploygate?publishing_type=automatic"
+fi

--- a/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
+++ b/src/main/groovy/com/deploygate/gradle/plugins/tasks/UploadArtifactTask.groovy
@@ -107,6 +107,10 @@ abstract class UploadArtifactTask extends DefaultTask {
         ].join(File.separator))
     }
 
+    // Derived from the real task inputs (apkInfo/aabInfo + deployment); subclasses override this
+    // with @Internal too. Annotated so java-gradle-plugin's validatePlugins (now wired into `check`
+    // via the plugin-publish plugin) does not flag the abstract declaration as un-annotated.
+    @Internal
     @NotNull
     abstract Provider<InputParams> getInputParamsProvider()
 


### PR DESCRIPTION
## Overview
The legacy Sonatype OSSRH was sunset on 2025-06-30, so the old publish target now returns HTTP 402. This migrates 2.10.0 publishing to **dual targets**:

- **Gradle Plugin Portal** (id `com.deploygate`) via `com.gradle.plugin-publish`
- **Maven Central** (`com.deploygate:gradle`) via the OSSRH Staging API compatibility endpoint, finalized with a POST that transfers the deployment to the Central Portal

## Changes
- **build.gradle**: Add `plugin-publish` 2.1.1 (the 2.x line is required for the Gradle 9.x acceptance-matrix host) and a `gradlePlugin {}` block that registers only the namespaced `com.deploygate` id. The legacy bare `deploygate` id keeps working via the hand-written descriptor, shipped alongside the generated one. Point the publish URL at `ossrh-staging-api.central.sonatype.com`. Drop the explicit sources/javadoc artifacts from the `release` publication because plugin-publish already enables `withSourcesJar()`/`withJavadocJar()` on `components.java`.
- **release.sh**: Run `publishPlugins` alongside the Maven publish, then issue the finalization POST (`publishing_type=automatic`) to release to Maven Central.
- **release.yml**: Wire `GRADLE_PORTAL_PUBLISH_KEY/SECRET` and the Central Portal token; update the Slack message.
- **README**: Lead with the plugins DSL (resolved from the Portal) and drop the now-unnecessary `resolutionStrategy` workaround; keep the legacy `buildscript` classpath path for back-compat.
- **UploadArtifactTask**: Annotate the abstract `inputParamsProvider` getter with `@Internal` so `validatePlugins` (now wired into `check` by java-gradle-plugin) passes.

## Local verification (wrapper 8.14.3 / JDK 17)
- `validatePlugins` ✅ / `publishToMavenLocal` (release, pluginMaven, marker publications) ✅ / `spotlessCheck` ✅
- Full unit test suite: 135 passing (against the DeployGate mock server)
- Confirmed the jar ships both `deploygate.properties` (legacy) and `com.deploygate.properties` (new)
- Temporarily bumped the wrapper to 9.4.1: `testPluginAcceptanceTest --dry-run` succeeds → plugin-publish 2.1.1 configures on the Gradle 9.x acceptance-matrix rows

## Post-merge steps
1. Re-point `git tag -f 2.10.0` onto the new HEAD and force-push to trigger release.yml
2. GitHub Secrets are already registered (`GRADLE_PORTAL_PUBLISH_KEY/SECRET`, and `SHARED_NEXUS_TOKEN_*` updated with the Central token). The `_TOKEN`-less `SHARED_NEXUS_USERNAME/PASSWORD` are unreferenced and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)