### PR TITLE
fix: consolidate publishing onto pluginMaven to fix release signing collision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,14 +347,14 @@ afterEvaluate {
         }
 
         publications {
-            release(MavenPublication) {
-                // The plugin-publish plugin enables withSourcesJar()/withJavadocJar() on the java
-                // component, so components.java already carries the sources and javadoc jars; adding
-                // them again here would fail with "multiple artifacts with the identical ... classifier".
-                from components.java
-                groupId = project.group
+            // java-gradle-plugin (via plugin-publish) already creates the `pluginMaven` publication
+            // from components.java, with the sources and javadoc jars attached. Reuse it for BOTH
+            // Maven Central and the Plugin Portal rather than maintaining a second hand-rolled
+            // publication: a single publication means a single set of artifacts and a single signing
+            // task, which avoids two Sign tasks writing the same `*.asc` files. Keep the Maven Central
+            // coordinate as `com.deploygate:gradle` (not the project name) for back-compat.
+            pluginMaven {
                 artifactId = archivesBaseName
-                version = project.version
                 pom {
                     name = "Gradle DeployGate Plugin"
                     description = "This is the DeployGate plugin for the Gradle. You can build and deploy your apps to DeployGate by running a single task."
@@ -378,12 +378,14 @@ afterEvaluate {
         }
 
         signing {
-            required { (isRelease() || System.getenv("RELEASE_SCRIPT_TEST") == "true") && gradle.taskGraph.hasTask("publishReleasePublicationToMavenRepository") }
+            required { (isRelease() || System.getenv("RELEASE_SCRIPT_TEST") == "true") && gradle.taskGraph.hasTask("publishPluginMavenPublicationToMavenRepository") }
 
             def signingKey = findProperty("signingKey")
             def signingPassword = findProperty("signingPassword")
             useInMemoryPgpKeys(signingKey, signingPassword)
-            publishing.publications.configureEach { publication -> sign publication }
+            // No explicit `sign` call: the plugin-publish plugin already signs the `pluginMaven` and
+            // marker publications once the signing plugin is applied. Adding our own `sign` here would
+            // double-sign the shared jars and produce conflicting `*.asc` outputs.
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -378,7 +378,15 @@ afterEvaluate {
         }
 
         signing {
-            required { (isRelease() || System.getenv("RELEASE_SCRIPT_TEST") == "true") && gradle.taskGraph.hasTask("publishPluginMavenPublicationToMavenRepository") }
+            // Match by task name rather than gradle.taskGraph.hasTask("<name>"): hasTask compares the
+            // full task path (e.g. ":publishPluginMavenPublicationToMavenRepository"), so the bare name
+            // never matched and signing was effectively never "required". Matching the name makes the
+            // gate fail fast when a release runs without a signing key.
+            required {
+                (isRelease() || System.getenv("RELEASE_SCRIPT_TEST") == "true") && gradle.taskGraph.allTasks.any {
+                    it.name == "publishPluginMavenPublicationToMavenRepository"
+                }
+            }
 
             def signingKey = findProperty("signingKey")
             def signingPassword = findProperty("signingPassword")

--- a/release.sh
+++ b/release.sh
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 # Publish in a single build to:
-#   * Maven Central  -> publishReleasePublicationToMavenRepository (com.deploygate:gradle)
-#   * Plugin Portal  -> publishPlugins                            (id com.deploygate)
+#   * Maven Central  -> publishPluginMavenPublicationToMavenRepository (com.deploygate:gradle)
+#   * Plugin Portal  -> publishPlugins                                 (id com.deploygate)
 ./gradlew clean build \
-    publishReleasePublicationToMavenRepository \
+    publishPluginMavenPublicationToMavenRepository \
     publishPlugins \
     --stacktrace
 


### PR DESCRIPTION
## Problem
The 2.10.0 release [failed](https://github.com/DeployGate/gradle-deploygate-plugin/actions/runs/27588713901) at `Task :signPluginMavenPublication`:

> Task ':publishReleasePublicationToMavenRepository' uses this output of task ':signPluginMavenPublication' (`*.asc`) without declaring an explicit or implicit dependency.

**Root cause:** the hand-rolled `release` publication and the plugin-publish-managed `pluginMaven` publication reference the *same* physical jars. With signing required, `signReleasePublication` and `signPluginMavenPublication` both write the same `*.asc` files, and the Central publish task consumes an `.asc` produced by the other publication's sign task. (Local `publishToMavenLocal` didn't catch this because signing was `SKIPPED` there.)

Nothing was published — Maven Central returns 404 for `com.deploygate:gradle:2.10.0`, so the same version can be re-released after this fix.

## Fix
Drop the separate `release` publication and reuse plugin-publish's `pluginMaven` for **both** Maven Central and the Plugin Portal. One publication ⇒ one set of artifacts ⇒ one signing task per artifact ⇒ no `.asc` collision.

- **build.gradle**: configure `pluginMaven` (set `artifactId = gradle` for back-compat + the pom) instead of a second publication; remove the explicit `sign` call (plugin-publish already signs `pluginMaven` + marker); gate signing on `publishPluginMavenPublicationToMavenRepository`.
- **release.sh**: publish via `publishPluginMavenPublicationToMavenRepository`.

The marker still depends on `com.deploygate:gradle` (verified), and the jar still ships both `deploygate.properties` and `com.deploygate.properties`.

## Verification (local, throwaway GPG key)
A signing-required (`RELEASE_SCRIPT_TEST=true`) publish of `pluginMaven` + the marker to a `file://` repo **succeeds with no implicit-dependency error**, emitting signed `jar`/`sources`/`javadoc`/`module`/`pom` (+ `.asc`) for `com.deploygate:gradle:2.10.0` and the signed marker pom. `spotlessCheck` and `validatePlugins` pass.

## After merge
Re-point `git tag -f 2.10.0` onto the new HEAD and force-push to re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)